### PR TITLE
fix(historyTable): improve and generalize table styles

### DIFF
--- a/apps/root/src/pages/history/components/historyTable/index.tsx
+++ b/apps/root/src/pages/history/components/historyTable/index.tsx
@@ -65,18 +65,6 @@ const StyledBackgroundPaper = styled(BackgroundPaper)`
   align-items: center;
 `;
 
-const StyledFirstTableCell = styled(TableCell)`
-  ${({ theme: { spacing } }) => `
-  padding-left: ${spacing(10)};
-`}
-`;
-
-const StyledLastTableCell = styled(TableCell)`
-  ${({ theme: { spacing } }) => `
-  padding-right: ${spacing(10)};
-`}
-`;
-
 const StyledViewReceiptButton = styled(Button).attrs({ variant: 'text' })`
   padding: 0;
   min-width: 0;
@@ -338,12 +326,12 @@ const HistoryTableRow: ItemContent<TransactionEvent, TableContext> = (
   const { dateTime, operation, sourceWallet, ...transaction } = getTxEventRowData(txEvent, intl);
   return (
     <>
-      <StyledFirstTableCell>
+      <TableCell>
         <StyledCellContainer direction="column">
           <StyledBodySmallRegularTypo2>{dateTime.date}</StyledBodySmallRegularTypo2>
           <StyledBodySmallLabelTypography>{dateTime.time}</StyledBodySmallLabelTypography>
         </StyledCellContainer>
-      </StyledFirstTableCell>
+      </TableCell>
       <TableCell>
         <StyledCellContainer direction="column">
           <StyledBodySmallRegularTypo2>{operation}</StyledBodySmallRegularTypo2>
@@ -380,7 +368,7 @@ const HistoryTableRow: ItemContent<TransactionEvent, TableContext> = (
           </StyledBodySmallRegularTypo2>
         </StyledCellContainer>
       </TableCell>
-      <StyledLastTableCell>
+      <TableCell>
         <StyledViewReceiptButton onClick={() => setShowReceipt(transaction)}>
           <StyledCellContainer direction="column" align="center">
             <ReceiptIcon />
@@ -389,18 +377,18 @@ const HistoryTableRow: ItemContent<TransactionEvent, TableContext> = (
             </Typography>
           </StyledCellContainer>
         </StyledViewReceiptButton>
-      </StyledLastTableCell>
+      </TableCell>
     </>
   );
 };
 
 const HistoryTableHeader = () => (
   <TableRow>
-    <StyledFirstTableCell sx={{ width: '15%' }}>
+    <TableCell sx={{ width: '15%' }}>
       <StyledBodySmallLabelTypography>
         <FormattedMessage description="date" defaultMessage="Date" />
       </StyledBodySmallLabelTypography>
-    </StyledFirstTableCell>
+    </TableCell>
     <TableCell sx={{ width: '15%' }}>
       <StyledBodySmallLabelTypography>
         <FormattedMessage description="operation" defaultMessage="Operation" />
@@ -426,11 +414,11 @@ const HistoryTableHeader = () => (
         <FormattedMessage description="sourceWallet" defaultMessage="Source Wallet" />
       </StyledBodySmallLabelTypography>
     </TableCell>
-    <StyledLastTableCell sx={{ width: '10%' }}>
+    <TableCell sx={{ width: '10%' }}>
       <StyledBodySmallLabelTypography>
         <FormattedMessage description="details" defaultMessage="Details" />
       </StyledBodySmallLabelTypography>
-    </StyledLastTableCell>
+    </TableCell>
   </TableRow>
 );
 

--- a/packages/ui-library/src/theme/variants/table-variants.ts
+++ b/packages/ui-library/src/theme/variants/table-variants.ts
@@ -1,5 +1,6 @@
 import type { Components } from '@mui/material/styles';
 import { colors } from '../colors';
+import { SPACING } from '../constants';
 
 export const buildTableVariant = (mode: 'light' | 'dark'): Components => ({
   MuiTableContainer: {
@@ -9,17 +10,32 @@ export const buildTableVariant = (mode: 'light' | 'dark'): Components => ({
         '.MuiTableCell-root': {
           borderBottom: `1px solid ${colors[mode].border.border2}`,
           borderRadius: '0px',
+          '&:first-of-type': {
+            paddingLeft: `${SPACING(10)}`,
+            borderTopLeftRadius: SPACING(2),
+            borderBottomLeftRadius: SPACING(2),
+          },
+          '&:last-of-type': {
+            paddingRight: `${SPACING(10)}`,
+            borderTopRightRadius: SPACING(2),
+            borderBottomRightRadius: SPACING(2),
+          },
         },
+        '.MuiTableRow-root': {},
         '&.noSeparateRows': {
           backgroundColor: `${colors[mode].background.secondary} !important`,
           '.MuiTableRow-root': {
             backgroundColor: `inherit !important`,
+            borderRadius: 0,
           },
           '.MuiTableRow-head': {
             backgroundColor: `${colors[mode].background.secondary} !important`,
           },
           '.MuiTable-root': {
             borderSpacing: '0px !important',
+          },
+          '.MuiTableCell-root': {
+            padding: SPACING(4),
           },
         },
       },

--- a/packages/ui-library/src/theme/variants/table-variants.ts
+++ b/packages/ui-library/src/theme/variants/table-variants.ts
@@ -21,7 +21,6 @@ export const buildTableVariant = (mode: 'light' | 'dark'): Components => ({
             borderBottomRightRadius: SPACING(2),
           },
         },
-        '.MuiTableRow-root': {},
         '&.noSeparateRows': {
           backgroundColor: `${colors[mode].background.secondary} !important`,
           '.MuiTableRow-root': {


### PR DESCRIPTION
Current
<img width="1050" alt="Screenshot 2024-05-27 at 2 46 22 PM" src="https://github.com/Balmy-protocol/dca-fe/assets/144699868/2e9f74e8-f887-4cb6-8833-e9ba37646638">

Expected
<img width="1048" alt="Screenshot 2024-05-27 at 2 45 17 PM" src="https://github.com/Balmy-protocol/dca-fe/assets/144699868/b22e8238-2b71-480d-bc4b-980b5702b53d">
