### PR TITLE
fix(dca): better handling for fetching allowed pairs

### DIFF
--- a/apps/root/src/frame/index.tsx
+++ b/apps/root/src/frame/index.tsx
@@ -30,6 +30,7 @@ import { Config, WagmiProvider } from 'wagmi';
 import LightBackgroundGrid from './components/background-grid/light';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import NetworkUpdater from '@state/config/networkUpdater';
+import usePairService from '@hooks/usePairService';
 
 declare module 'styled-components' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -85,15 +86,11 @@ const StyledGridBg = styled.div`
 
 const AppFrame = ({ config: { wagmiClient }, initialChain }: AppFrameProps) => {
   const providerService = useProviderService();
-  // const accountService = useAccountService();
-  // const account = useAccount();
-  // const [hasSetNetwork, setHasSetNetwork] = React.useState(false);
-  // const aggSupportedNetworks = useSdkChains();
+  const pairService = usePairService();
   const currentBreakPoint = useCurrentBreakpoint();
   const themeMode = useThemeMode();
 
   const dispatch = useAppDispatch();
-  // const currentNetwork = useCurrentNetwork();
 
   React.useEffect(() => {
     providerService.setChainChangedCallback((chainId) => {
@@ -102,7 +99,9 @@ const AppFrame = ({ config: { wagmiClient }, initialChain }: AppFrameProps) => {
         dispatch(setNetwork(networkToSet));
       }
     });
+    // First promises to be executed for every session
     void dispatch(startFetchingTokenLists());
+    void pairService.fetchAvailablePairs();
   }, []);
 
   return (

--- a/apps/root/src/hooks/useDcaTokens.ts
+++ b/apps/root/src/hooks/useDcaTokens.ts
@@ -15,7 +15,7 @@ function useDcaTokens(chainId: number, includeYield: boolean = false): TokenList
 
   const tokens = useServiceEvents<PairServiceData, PairService, 'getTokens'>(pairService, 'getTokens');
 
-  const chainTokens = tokens[chainId];
+  const chainTokens = tokens[chainId] || {};
 
   return Object.keys(chainTokens)
     .filter(

--- a/apps/root/src/services/pairService.ts
+++ b/apps/root/src/services/pairService.ts
@@ -39,11 +39,7 @@ export default class PairService extends EventsManager<PairServiceData> {
 
   constructor(sdkService: SdkService) {
     super({ availablePairs: {}, minSwapInterval: {}, hasFetchedAvailablePairs: false, tokens: {}, yieldOptions: {} });
-
     this.sdkService = sdkService;
-
-    // Wait a bit for react to initialize before calling this
-    setTimeout(() => this.fetchAvailablePairs(), 500);
   }
 
   get availablePairs() {


### PR DESCRIPTION
### Bug context
In the constructor of the `pairService` class, the `setTimeout` was delayed to allow React to load. React loaded so quickly that the query wasn't able to load in time. This issue was only reproducible for me in the production environment due to the high performance.

I have prevented this potential issue and moved this logic to a more standardized block.