### PR TITLE
fix(dca): set pending tx color to primary

### DIFF
--- a/apps/root/src/pages/dca/positions/components/positions-list/current-positions/components/position-card-button/index.tsx
+++ b/apps/root/src/pages/dca/positions/components/positions-list/current-positions/components/position-card-button/index.tsx
@@ -88,7 +88,7 @@ const PositionCardButton = ({
             color="inherit"
             sx={{ display: 'flex', alignItems: 'center' }}
           >
-            <Typography variant="bodySmallRegular" component="span">
+            <Typography variant="bodySmallRegular" component="span" color="primary">
               <FormattedMessage description="pending transaction" defaultMessage="Pending transaction" />
             </Typography>
             <OpenInNewIcon style={{ fontSize: '1rem' }} />


### PR DESCRIPTION
### Previous behaviour
<img width="482" alt="Screenshot 2024-08-07 at 7 12 09 PM" src="https://github.com/user-attachments/assets/183af66a-7491-48d6-bf0e-c9ed0195872e">

### Expected behaviour
<img width="475" alt="Screenshot 2024-08-07 at 7 12 28 PM" src="https://github.com/user-attachments/assets/d51ed8bb-2f16-40fc-9047-85aec6e3ffee">
