### PR TITLE
fix(token-profile): feedback fixes

### DIFF
--- a/apps/root/src/common/components/net-worth/index.tsx
+++ b/apps/root/src/common/components/net-worth/index.tsx
@@ -65,7 +65,6 @@ const NetWorth = ({ walletSelector, chainId }: NetWorthProps) => {
         withAnimation
         value={totalAssetValue}
         variant="h4Bold"
-        addDolarSign
         size="large"
       />
     </StyledNetWorthContainer>

--- a/apps/root/src/common/components/networth-number/index.tsx
+++ b/apps/root/src/common/components/networth-number/index.tsx
@@ -9,13 +9,15 @@ import isUndefined from 'lodash/isUndefined';
 
 const StyledNetWorth = styled(Typography).attrs({ fontWeight: 700 })`
   ${({ theme: { palette } }) => `
-    color: ${colors[palette.mode].typography.typo1};
+    color: ${colors[palette.mode].typography.typo2};
   `}
 `;
 
-const StyledNetWorthDecimals = styled.div`
-  ${({ theme: { palette } }) => `
-    color: ${colors[palette.mode].typography.typo3};
+const StyledNetWorthDecimals = styled.div<{ $lightDecimals?: boolean }>`
+  ${({ theme: { palette }, $lightDecimals }) =>
+    $lightDecimals &&
+    `
+    color: ${colors[palette.mode].typography.typo4};
   `}
 `;
 
@@ -24,27 +26,18 @@ interface NetWorthNumberProps {
   withAnimation?: boolean;
   isLoading?: boolean;
   variant: TypographyProps['variant'];
-  fixNumber?: boolean;
-  addDolarSign?: boolean;
   size?: ButtonProps['size'];
+  isFiat?: boolean;
 }
 
-const NetWorthNumber = ({
-  value,
-  withAnimation,
-  isLoading,
-  variant,
-  fixNumber = true,
-  addDolarSign = false,
-  size,
-}: NetWorthNumberProps) => {
+const NetWorthNumber = ({ value, withAnimation, isLoading, variant, size, isFiat = true }: NetWorthNumberProps) => {
   const animatedNetWorth = useCountingAnimation(value);
   const networthToUse = withAnimation ? animatedNetWorth : value;
   const intl = useIntl();
   const showBalance = useShowBalances();
 
   const baseNumber = isNaN(networthToUse) ? 0 : networthToUse;
-  const fixedWorth = fixNumber ? baseNumber.toFixed(2) : baseNumber.toString();
+  const fixedWorth = isFiat ? baseNumber.toFixed(2) : baseNumber.toString();
   const [totalInteger, totalDecimal] = fixedWorth.split('.');
 
   return (
@@ -55,10 +48,10 @@ const NetWorthNumber = ({
         <ContainerBox>
           {showBalance ? (
             <>
-              {!!addDolarSign && '$'}
+              {isFiat && '$'}
               {formatUsdAmount({ amount: totalInteger || 0, intl })}
               {totalDecimal !== '' && !isUndefined(totalDecimal) && (
-                <StyledNetWorthDecimals>
+                <StyledNetWorthDecimals $lightDecimals={isFiat}>
                   {getDecimalSeparator(intl)}
                   {totalDecimal}
                 </StyledNetWorthDecimals>

--- a/apps/root/src/constants/routes.tsx
+++ b/apps/root/src/constants/routes.tsx
@@ -30,5 +30,9 @@ export const TRANSFER_ROUTE = {
   icon: <TransferIcon />,
 };
 
-export const TOKEN_PROFILE_ROUTE = 'token';
-export const HISTORY_ROUTE = 'history';
+export const TOKEN_PROFILE_ROUTE = {
+  key: 'token',
+};
+export const HISTORY_ROUTE = {
+  key: 'history',
+};

--- a/apps/root/src/constants/routes.tsx
+++ b/apps/root/src/constants/routes.tsx
@@ -29,3 +29,6 @@ export const TRANSFER_ROUTE = {
   key: 'transfer',
   icon: <TransferIcon />,
 };
+
+export const TOKEN_PROFILE_ROUTE = 'token';
+export const HISTORY_ROUTE = 'history';

--- a/apps/root/src/hooks/useNetWorth.ts
+++ b/apps/root/src/hooks/useNetWorth.ts
@@ -83,7 +83,14 @@ const useNetWorth = ({ walletSelector, chainId, tokens }: NetWorthProps) => {
   }
 
   let dcaAssetsTotalValue = 0;
-  let filteredPositions = currentPositions;
+  let filteredPositions = currentPositions.filter(
+    (position) =>
+      !(tokens && tokens.length) ||
+      tokens.some(
+        (filterToken) =>
+          getIsSameOrTokenEquivalent(filterToken, position.from) || getIsSameOrTokenEquivalent(filterToken, position.to)
+      )
+  );
   if (walletSelector !== ALL_WALLETS) {
     if (chainId && walletAddressToEvaluate) {
       filteredPositions = currentPositions.filter(

--- a/apps/root/src/pages/history/components/historyTable/index.tsx
+++ b/apps/root/src/pages/history/components/historyTable/index.tsx
@@ -19,6 +19,7 @@ import {
   BackgroundPaper,
   HourglassNotDoneEmoji,
   YawningFaceEmoji,
+  BaseContext,
 } from 'ui-library';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -268,7 +269,7 @@ const getTxEventRowData = (txEvent: TransactionEvent, intl: ReturnType<typeof us
   };
 };
 
-interface TableContext {
+interface TableContext extends BaseContext {
   setShowReceipt: SetStateCallback<TransactionEvent>;
   themeMode: 'light' | 'dark';
   intl: ReturnType<typeof useIntl>;

--- a/apps/root/src/pages/history/components/historyTable/index.tsx
+++ b/apps/root/src/pages/history/components/historyTable/index.tsx
@@ -19,7 +19,7 @@ import {
   BackgroundPaper,
   HourglassNotDoneEmoji,
   YawningFaceEmoji,
-  BaseContext,
+  VirtualizedTableContext,
 } from 'ui-library';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -269,7 +269,7 @@ const getTxEventRowData = (txEvent: TransactionEvent, intl: ReturnType<typeof us
   };
 };
 
-interface TableContext extends BaseContext {
+interface TableContext extends VirtualizedTableContext {
   setShowReceipt: SetStateCallback<TransactionEvent>;
   themeMode: 'light' | 'dark';
   intl: ReturnType<typeof useIntl>;

--- a/apps/root/src/pages/home/components/activity/index.tsx
+++ b/apps/root/src/pages/home/components/activity/index.tsx
@@ -241,8 +241,8 @@ const Activity = ({ selectedWalletOption }: ActivityProps) => {
   const parsedReceipt = React.useMemo(() => parseTransactionEventToTransactionReceipt(showReceipt), [showReceipt]);
 
   const onSeeAllHistory = () => {
-    dispatch(changeRoute(HISTORY_ROUTE));
-    pushToHistory(`/${HISTORY_ROUTE}`);
+    dispatch(changeRoute(HISTORY_ROUTE.key));
+    pushToHistory(`/${HISTORY_ROUTE.key}`);
     trackEvent('Home - Go to see all history');
   };
 

--- a/apps/root/src/pages/home/components/activity/index.tsx
+++ b/apps/root/src/pages/home/components/activity/index.tsx
@@ -44,6 +44,7 @@ import useIsSomeWalletIndexed from '@hooks/useIsSomeWalletIndexed';
 import { ALL_WALLETS, WalletOptionValues } from '@common/components/wallet-selector';
 import { formatUsdAmount } from '@common/utils/currency';
 import { findHubAddressVersion } from '@common/utils/parsing';
+import { HISTORY_ROUTE } from '@constants/routes';
 
 const StyledNoActivity = styled.div`
   ${({ theme: { spacing } }) => `
@@ -240,8 +241,8 @@ const Activity = ({ selectedWalletOption }: ActivityProps) => {
   const parsedReceipt = React.useMemo(() => parseTransactionEventToTransactionReceipt(showReceipt), [showReceipt]);
 
   const onSeeAllHistory = () => {
-    dispatch(changeRoute('history'));
-    pushToHistory('/history');
+    dispatch(changeRoute(HISTORY_ROUTE));
+    pushToHistory(`/${HISTORY_ROUTE}`);
     trackEvent('Home - Go to see all history');
   };
 

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -57,6 +57,7 @@ import TokenIconMultichain from '../token-icon-multichain';
 import useAccountService from '@hooks/useAccountService';
 import { Link } from 'react-router-dom';
 import usePushToHistory from '@hooks/usePushToHistory';
+import { TOKEN_PROFILE_ROUTE } from '@constants/routes';
 
 const StyledNoWallet = styled(ForegroundPaper).attrs({ variant: 'outlined' })`
   ${({ theme: { spacing } }) => `
@@ -177,7 +178,7 @@ const PortfolioNotConnected = () => {
 const PortfolioBodyItem: ItemContent<BalanceItem, Context> = (
   index: number,
   { totalBalanceInUnits, tokens, isLoadingPrice, price, totalBalanceUsd, relativeBalance }: BalanceItem,
-  { intl, showBalances, hoveredRow }
+  { intl, showBalances }
 ) => {
   const firstAddedToken = tokens[0].token;
   return (
@@ -250,7 +251,7 @@ const PortfolioBodyItem: ItemContent<BalanceItem, Context> = (
         )}
         <StyledTableEnd>
           <StyledLink to={`/token/${firstAddedToken.chainId}-${firstAddedToken.address}`}>
-            <AnimatedChevronRightIcon $hovered={hoveredRow === index} />
+            <AnimatedChevronRightIcon />
           </StyledLink>
         </StyledTableEnd>
       </Hidden>
@@ -300,7 +301,6 @@ const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
   const intl = useIntl();
   const showBalances = useShowBalances();
   const showSmallBalances = useShowSmallBalances();
-  const [hoveredRow, setHoveredRow] = React.useState<number | undefined>();
   const pushToHistory = usePushToHistory();
 
   const portfolioBalances = React.useMemo<BalanceItem[]>(() => {
@@ -404,9 +404,9 @@ const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
   }, [accountService]);
 
   const onRowClick = React.useCallback(
-    (index: number) => {
-      const token = portfolioBalances[index].tokens[0].token;
-      pushToHistory(`/token/${token.chainId}-${token.address}`);
+    (rowIndex: number) => {
+      const token = portfolioBalances[rowIndex].tokens[0].token;
+      pushToHistory(`/${TOKEN_PROFILE_ROUTE.key}/${token.chainId}-${token.address}`);
     },
     [portfolioBalances, pushToHistory]
   );
@@ -415,14 +415,9 @@ const Portfolio = ({ selectedWalletOption }: PortfolioProps) => {
     () => ({
       intl,
       showBalances,
-      hoveredRow,
-      rowContext: {
-        onClick: onRowClick,
-        setHovered: setHoveredRow,
-        style: { cursor: 'pointer' },
-      },
+      onRowClick,
     }),
-    [intl, showBalances, hoveredRow, onRowClick]
+    [intl, showBalances, onRowClick]
   );
 
   const isLoading = isLoadingAllBalances || isLoggingUser;

--- a/apps/root/src/pages/home/components/portfolio/index.tsx
+++ b/apps/root/src/pages/home/components/portfolio/index.tsx
@@ -23,7 +23,7 @@ import {
   HiddenNumber,
   colors,
   AnimatedChevronRightIcon,
-  BaseContext,
+  VirtualizedTableContext,
 } from 'ui-library';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
@@ -103,7 +103,7 @@ interface PortfolioProps {
   selectedWalletOption: WalletOptionValues;
 }
 
-interface Context extends BaseContext {
+interface Context extends VirtualizedTableContext {
   intl: ReturnType<typeof useIntl>;
   showBalances: boolean;
   hoveredRow?: number;

--- a/apps/root/src/pages/home/components/widget-frame/index.tsx
+++ b/apps/root/src/pages/home/components/widget-frame/index.tsx
@@ -109,7 +109,6 @@ const WidgetFrame = ({
           </Typography>
           <NetWorthNumber
             value={assetValue}
-            addDolarSign
             withAnimation={false}
             isLoading={isLoading}
             variant="bodyBold"

--- a/apps/root/src/pages/position-detail/components/summary-container/components/position-data/index.tsx
+++ b/apps/root/src/pages/position-detail/components/summary-container/components/position-data/index.tsx
@@ -242,7 +242,7 @@ const Details = ({ position, pendingTransaction }: DetailsProps) => {
                   <ContainerBox gap={1} alignItems="center">
                     <TokenIcon isInChip size={7} token={to} />
                     <NetWorthNumber
-                      fixNumber={false}
+                      isFiat={false}
                       value={Number(formatCurrencyAmount({ amount: toWithdraw.amount || 0n, token: to, sigFigs: 4 }))}
                       variant="bodyLargeBold"
                     />

--- a/apps/root/src/pages/token-profile/balance-table/index.tsx
+++ b/apps/root/src/pages/token-profile/balance-table/index.tsx
@@ -21,7 +21,7 @@ import {
   Hidden,
   HiddenNumber,
   colors,
-  BaseContext,
+  VirtualizedTableContext,
 } from 'ui-library';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
@@ -73,7 +73,7 @@ interface BalanceTableProps {
   token: Token;
 }
 
-interface Context extends BaseContext {
+interface Context extends VirtualizedTableContext {
   intl: ReturnType<typeof useIntl>;
   showBalances: boolean;
 }

--- a/apps/root/src/pages/token-profile/balance-table/index.tsx
+++ b/apps/root/src/pages/token-profile/balance-table/index.tsx
@@ -21,6 +21,7 @@ import {
   Hidden,
   HiddenNumber,
   colors,
+  BaseContext,
 } from 'ui-library';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
@@ -72,7 +73,7 @@ interface BalanceTableProps {
   token: Token;
 }
 
-interface Context {
+interface Context extends BaseContext {
   intl: ReturnType<typeof useIntl>;
   showBalances: boolean;
 }
@@ -285,7 +286,11 @@ const BalanceTable = ({ token }: BalanceTableProps) => {
   const intlContext = React.useMemo(() => ({ intl, showBalances }), [intl, showBalances]);
   const showSmallBalances = useShowSmallBalances();
 
-  const BalanceTableBalances = React.useMemo<BalanceItem[]>(() => {
+  const { balanceTableBalances, totalAmountInUnits } = React.useMemo<{
+    balanceTableBalances: BalanceItem[];
+    totalAmountInUnits: string;
+  }>(() => {
+    let acumTotalAmountInUnits = 0;
     const balanceTokens = Object.values(allBalances).reduce<Record<string, BalanceItem>>(
       (acc, { balancesAndPrices, isLoadingChainPrices }) => {
         Object.entries(balancesAndPrices)
@@ -297,6 +302,7 @@ const BalanceTable = ({ token }: BalanceTableProps) => {
               }
               const tokenKey = `${tokenInfo.token.chainId}-${tokenAddress}-${walletAddress}`;
               const parsedBalance = parseFloat(formatUnits(balance, tokenInfo.token.decimals));
+              acumTotalAmountInUnits += parsedBalance;
               // eslint-disable-next-line no-param-reassign
               acc[tokenKey] = {
                 walletAddress: walletAddress as ViemAddress,
@@ -322,7 +328,14 @@ const BalanceTable = ({ token }: BalanceTableProps) => {
         assetsTotalValue.wallet && value.balanceUsd ? (value.balanceUsd / assetsTotalValue.wallet) * 100 : 0,
     })).filter((balance) => showSmallBalances || isUndefined(balance.balanceUsd) || balance.balanceUsd >= 1);
 
-    return orderBy(mappedBalances, [(item) => isUndefined(item.balanceUsd), 'balanceUsd'], ['asc', 'desc']);
+    return {
+      balanceTableBalances: orderBy(
+        mappedBalances,
+        [(item) => isUndefined(item.balanceUsd), 'balanceUsd'],
+        ['asc', 'desc']
+      ),
+      totalAmountInUnits: parseExponentialNumberToString(acumTotalAmountInUnits),
+    };
   }, [allBalances, showSmallBalances]);
 
   if (user?.status !== UserStatus.loggedIn && !isLoggingUser) {
@@ -337,12 +350,17 @@ const BalanceTable = ({ token }: BalanceTableProps) => {
       assetValue={assetsTotalValue.wallet}
       Icon={EmptyWalletIcon}
       totalValue={totalAssetValue}
-      showPercentage
-      widgetId="BalanceTable"
+      widgetId="TokenProfileBalanceTable"
       title={<FormattedMessage defaultMessage="All wallets" description="allWallets" />}
+      subtitle={`${formatCurrencyAmount({
+        amount: parseUnits(totalAmountInUnits, token.decimals),
+        token,
+        sigFigs: 3,
+        intl,
+      })} ${token.symbol}`}
     >
       <VirtualizedTable
-        data={isLoading ? (SKELETON_ROWS as unknown as BalanceItem[]) : BalanceTableBalances}
+        data={isLoading ? (SKELETON_ROWS as unknown as BalanceItem[]) : balanceTableBalances}
         VirtuosoTableComponents={VirtuosoTableComponents}
         header={BalanceTableTableHeader}
         itemContent={isLoading ? BalanceTableBodySkeleton : BalanceTableBodyItem}

--- a/apps/root/src/pages/token-profile/frame/index.tsx
+++ b/apps/root/src/pages/token-profile/frame/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useTrackEvent from '@hooks/useTrackEvent';
 import { BackControl, ContainerBox, Grid, StyledNonFormContainer } from 'ui-library';
-import { DASHBOARD_ROUTE } from '@constants/routes';
+import { DASHBOARD_ROUTE, TOKEN_PROFILE_ROUTE } from '@constants/routes';
 import { useParams } from 'react-router-dom';
 import { defineMessage, useIntl } from 'react-intl';
 import useToken from '@hooks/useToken';
@@ -39,7 +39,7 @@ const TokenProfileFrame = () => {
   });
 
   React.useEffect(() => {
-    dispatch(changeRoute('token'));
+    dispatch(changeRoute(TOKEN_PROFILE_ROUTE));
     trackEvent('Home - Visit Token Profile', { tokenListId });
   }, []);
 

--- a/apps/root/src/pages/token-profile/frame/index.tsx
+++ b/apps/root/src/pages/token-profile/frame/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import useTrackEvent from '@hooks/useTrackEvent';
 import { BackControl, ContainerBox, Grid, StyledNonFormContainer } from 'ui-library';
 import { DASHBOARD_ROUTE } from '@constants/routes';
-import useReplaceHistory from '@hooks/useReplaceHistory';
 import { useParams } from 'react-router-dom';
 import { defineMessage, useIntl } from 'react-intl';
 import useToken from '@hooks/useToken';
@@ -15,9 +14,13 @@ import TokenProfileHeader from '../header';
 import Explorers from '../explorers';
 import TokenHistory from '../components/token-history';
 import MarketStats from '../market-stats';
+import usePushToHistory from '@hooks/usePushToHistory';
+import { useAppDispatch } from '@state/hooks';
+import { changeRoute } from '@state/tabs/actions';
 
 const TokenProfileFrame = () => {
-  const replaceHistory = useReplaceHistory();
+  const pushToHistory = usePushToHistory();
+  const dispatch = useAppDispatch();
   const trackEvent = useTrackEvent();
   const intl = useIntl();
   const { tokenListId } = useParams<{ tokenListId: string }>();
@@ -36,11 +39,12 @@ const TokenProfileFrame = () => {
   });
 
   React.useEffect(() => {
+    dispatch(changeRoute('token'));
     trackEvent('Home - Visit Token Profile', { tokenListId });
   }, []);
 
   const handleGoBack = () => {
-    replaceHistory(`/${DASHBOARD_ROUTE.key}`);
+    pushToHistory(`/${DASHBOARD_ROUTE.key}`);
   };
 
   const token = React.useMemo(() => tokenParam || getProtocolToken(Number(tokenChain) || 1), [tokenParam, tokenChain]);

--- a/apps/root/src/pages/token-profile/frame/index.tsx
+++ b/apps/root/src/pages/token-profile/frame/index.tsx
@@ -39,7 +39,7 @@ const TokenProfileFrame = () => {
   });
 
   React.useEffect(() => {
-    dispatch(changeRoute(TOKEN_PROFILE_ROUTE));
+    dispatch(changeRoute(TOKEN_PROFILE_ROUTE.key));
     trackEvent('Home - Visit Token Profile', { tokenListId });
   }, []);
 

--- a/apps/root/src/pages/token-profile/header/index.tsx
+++ b/apps/root/src/pages/token-profile/header/index.tsx
@@ -1,21 +1,17 @@
 import React from 'react';
-import useNetWorth from '@hooks/useNetWorth';
 import { Token } from 'common-types';
 import TokenIcon from '@common/components/token-icon';
 import { ContainerBox, Typography, colors } from 'ui-library';
 import NetWorthNumber from '@common/components/networth-number';
+import useRawUsdPrice from '@hooks/useUsdRawPrice';
+import { parseBaseUsdPriceToNumber } from '@common/utils/currency';
 
 interface TokenProfileHeaderProps {
   token?: Token;
 }
 
 const TokenProfileHeader = ({ token }: TokenProfileHeaderProps) => {
-  const { totalAssetValue, isLoadingAllBalances, isLoadingSomePrices } = useNetWorth({
-    walletSelector: 'allWallets',
-    tokens: token && [token],
-  });
-
-  const isLoading = isLoadingAllBalances || isLoadingSomePrices;
+  const [price, isLoading] = useRawUsdPrice(token);
 
   return (
     <ContainerBox flexDirection="column" gap={3}>
@@ -25,8 +21,8 @@ const TokenProfileHeader = ({ token }: TokenProfileHeaderProps) => {
           {token?.name}
         </Typography>
       </ContainerBox>
-      {(totalAssetValue !== undefined || isLoading) && (
-        <NetWorthNumber variant="h4Bold" withAnimation addDolarSign value={totalAssetValue} isLoading={isLoading} />
+      {(price !== undefined || isLoading) && (
+        <NetWorthNumber variant="h4Bold" value={parseBaseUsdPriceToNumber(price)} isLoading={isLoading} />
       )}
     </ContainerBox>
   );

--- a/apps/root/src/pages/token-profile/historical-prices/index.tsx
+++ b/apps/root/src/pages/token-profile/historical-prices/index.tsx
@@ -117,7 +117,7 @@ const TimestampMap: Record<GraphContainerPeriods, number> = {
   [GraphContainerPeriods.all]: Infinity,
 };
 
-const DEFAULT_PERIOD = GraphContainerPeriods.day;
+const DEFAULT_PERIOD = GraphContainerPeriods.week;
 
 const TokenHistoricalPrices = ({ token }: TokenHistoricalPricesProps) => {
   const mode = useThemeMode();
@@ -299,11 +299,11 @@ const TokenHistoricalPrices = ({ token }: TokenHistoricalPricesProps) => {
               />
               <Tooltip content={({ payload }) => <GraphTooltip payload={payload} />} />
               <XAxis
-                interval="preserveStartEnd"
+                interval="preserveEnd"
                 scale="time"
                 type="number"
                 domain={['auto', 'auto']}
-                minTickGap={12}
+                minTickGap={30}
                 dataKey="timestamp"
                 includeHidden
                 axisLine={false}
@@ -312,6 +312,10 @@ const TokenHistoricalPrices = ({ token }: TokenHistoricalPricesProps) => {
                   const formattedDate = DateTime.fromSeconds(value).toFormat(PeriodDateFormatMap[selectedPeriod]);
                   return formattedDate;
                 }}
+                tick={{
+                  fontSize: 12,
+                  fontWeight: 500,
+                }}
               />
               <YAxis
                 tickMargin={0}
@@ -319,6 +323,10 @@ const TokenHistoricalPrices = ({ token }: TokenHistoricalPricesProps) => {
                 strokeWidth="0px"
                 domain={['auto', 'auto']}
                 axisLine={false}
+                tick={{
+                  fontSize: 12,
+                  fontWeight: 500,
+                }}
                 tickLine={false}
               />
             </ComposedChart>

--- a/apps/root/src/pages/token-profile/market-stats/index.tsx
+++ b/apps/root/src/pages/token-profile/market-stats/index.tsx
@@ -3,12 +3,12 @@ import { useThemeMode } from '@state/config/hooks';
 import { Token } from 'common-types';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
-import { colors, ContainerBox, ForegroundPaper, Skeleton, Typography } from 'ui-library';
+import { BackgroundPaper, colors, ContainerBox, Skeleton, Typography } from 'ui-library';
 import usePriceService from '@hooks/usePriceService';
 import { TokenPercentageChanges } from '@services/priceService';
 import TokenHistoricalPrices from '../historical-prices';
 
-const StyledMarketStatsContainer = styled(ForegroundPaper).attrs({ variant: 'outlined' })`
+const StyledMarketStatsContainer = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
   ${({ theme: { spacing } }) => `
     display: flex;
     flex-direction: column;

--- a/apps/root/src/pages/token-profile/token-distribution/index.tsx
+++ b/apps/root/src/pages/token-profile/token-distribution/index.tsx
@@ -11,8 +11,6 @@ import {
   Grid,
   BackgroundPaper,
   HiddenNumber,
-  LinearProgress,
-  linearProgressClasses,
   Skeleton,
 } from 'ui-library';
 import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
@@ -91,29 +89,12 @@ const StyledBullet = styled.div<{ fill: string }>`
   `}
 `;
 
-const BorderLinearProgress = styled(LinearProgress)<{ fill?: string }>(
-  ({
-    theme: {
-      palette: { mode },
-      spacing,
-    },
-    fill,
-  }) => ({
-    background: colors[mode].background.primary,
-    height: spacing(2),
-    [`& .${linearProgressClasses.bar}`]: {
-      borderRadius: spacing(3),
-      background: fill,
-    },
-  })
-);
-
 const DATA_KEY_TO_LABEL: Record<
   keyof ReturnType<typeof useNetWorth>['assetsTotalValue'],
   ReturnType<typeof defineMessage>
 > = {
-  dca: defineMessage({ description: 'token-profile.distribution.dca', defaultMessage: 'DCA' }),
-  wallet: defineMessage({ description: 'token-profile.distribution.wallet', defaultMessage: 'Wallet' }),
+  dca: defineMessage({ description: 'token-profile.distribution.dca', defaultMessage: 'Recurring Investments' }),
+  wallet: defineMessage({ description: 'token-profile.distribution.wallet', defaultMessage: 'Spot' }),
 };
 
 const TokenDistributionLabelsSkeleton = () => (
@@ -122,15 +103,12 @@ const TokenDistributionLabelsSkeleton = () => (
       <Grid item xs={1}>
         <Skeleton variant="circular" width={SPACING(2)} height={SPACING(2)} />
       </Grid>
-      <Grid item xs={3}>
+      <Grid item xs={5}>
         <Typography variant="bodySmallSemibold">
           <Skeleton variant="text" width="3ch" />
         </Typography>
       </Grid>
-      <Grid item flex={1}>
-        <BorderLinearProgress variant="determinate" value={0} />
-      </Grid>
-      <Grid item xs={4} sx={{ textAlign: 'right' }}>
+      <Grid item xs={6}>
         <Typography variant="bodySmallRegular">
           <Typography variant="bodySmallSemibold">
             <Skeleton variant="text" width="4ch" />
@@ -142,15 +120,12 @@ const TokenDistributionLabelsSkeleton = () => (
       <Grid item xs={1}>
         <Skeleton variant="circular" width={SPACING(2)} height={SPACING(2)} />
       </Grid>
-      <Grid item xs={3}>
+      <Grid item xs={5}>
         <Typography variant="bodySmallSemibold">
           <Skeleton variant="text" width="3ch" />
         </Typography>
       </Grid>
-      <Grid item flex={1}>
-        <BorderLinearProgress variant="determinate" value={0} />
-      </Grid>
-      <Grid item xs={4} sx={{ textAlign: 'right' }}>
+      <Grid item xs={6}>
         <Typography variant="bodySmallRegular">
           <Typography variant="bodySmallSemibold">
             <Skeleton variant="text" width="4ch" />
@@ -162,15 +137,12 @@ const TokenDistributionLabelsSkeleton = () => (
       <Grid item xs={1}>
         <Skeleton variant="circular" width={SPACING(2)} height={SPACING(2)} />
       </Grid>
-      <Grid item xs={3}>
+      <Grid item xs={5}>
         <Typography variant="bodySmallSemibold">
           <Skeleton variant="text" width="3ch" />
         </Typography>
       </Grid>
-      <Grid item flex={1}>
-        <BorderLinearProgress variant="determinate" value={0} />
-      </Grid>
-      <Grid item xs={4} sx={{ textAlign: 'right' }}>
+      <Grid item xs={6}>
         <Typography variant="bodySmallRegular">
           <Typography variant="bodySmallSemibold">
             <Skeleton variant="text" width="4ch" />
@@ -211,7 +183,7 @@ const TokenDistribution = ({ token }: TokenDistributionProps) => {
     : Object.entries(assetsTotalValue).map(([entryKey, balance], index) => ({
         name: entryKey,
         value: balance,
-        label: DATA_KEY_TO_LABEL[entryKey as keyof typeof DATA_KEY_TO_LABEL],
+        label: intl.formatMessage(DATA_KEY_TO_LABEL[entryKey as keyof typeof DATA_KEY_TO_LABEL]),
         fill:
           CHART_COLOR_PRIORITIES[mode][index] || CHART_COLOR_PRIORITIES[mode][CHART_COLOR_PRIORITIES[mode].length - 1],
         relativeValue: (balance * 100) / totalAssetValue,
@@ -263,16 +235,16 @@ const TokenDistribution = ({ token }: TokenDistributionProps) => {
                 <Grid item xs={1}>
                   <StyledBullet fill={dataPoint.fill} />
                 </Grid>
-                <Grid item xs={3}>
-                  <Typography variant="bodySmallSemibold">{dataPoint.name}</Typography>
+                <Grid item xs={5} overflow="hidden" textOverflow="ellipsis">
+                  <Typography variant="bodySmallSemibold" noWrap>
+                    {dataPoint.label}
+                  </Typography>
                 </Grid>
-                <Grid item flex={1}>
-                  <BorderLinearProgress variant="determinate" value={dataPoint.relativeValue} fill={dataPoint.fill} />
-                </Grid>
-                <Grid item xs={4} sx={{ textAlign: 'right' }}>
+                <Grid item xs={6} display="flex" gap={0.5} justifyContent="end">
+                  <Typography variant="bodySmallSemibold">{dataPoint.relativeValue.toFixed(0)}%</Typography>
                   <Typography variant="bodySmallRegular">
                     {showBalances ? (
-                      `$${formatUsdAmount({ amount: dataPoint.value, intl })}`
+                      `($${formatUsdAmount({ amount: dataPoint.value, intl })})`
                     ) : (
                       <HiddenNumber size="small" />
                     )}

--- a/packages/ui-library/src/components/virtualized-table/index.tsx
+++ b/packages/ui-library/src/components/virtualized-table/index.tsx
@@ -59,7 +59,7 @@ const StyledBodySmallLabelTypography = styled(Typography).attrs(
   })
 )``;
 
-interface BaseContext {
+interface VirtualizedTableContext {
   rowContext?: {
     setHovered?: (index?: number) => void;
     style?: React.CSSProperties;
@@ -70,7 +70,7 @@ interface BaseContext {
 interface VirtualizedTableProps<Data, Context> {
   data: Data[];
   itemContent: ItemContent<Data, Context>;
-  context?: BaseContext & Context;
+  context?: VirtualizedTableContext & Context;
   fetchMore?: () => void;
   header: FixedHeaderContent;
   VirtuosoTableComponents: TableComponents<Data, Context>;
@@ -78,7 +78,7 @@ interface VirtualizedTableProps<Data, Context> {
   height?: React.CSSProperties['height'];
 }
 
-function buildVirtuosoTableComponents<D, C extends BaseContext>(): TableComponents<D, C> {
+function buildVirtuosoTableComponents<D, C extends VirtualizedTableContext>(): TableComponents<D, C> {
   return {
     Scroller: forwardRef<
       HTMLDivElement,
@@ -139,5 +139,5 @@ export {
   buildVirtuosoTableComponents,
   StyledBodySmallLabelTypography,
   type ItemContent,
-  type BaseContext,
+  type VirtualizedTableContext,
 };

--- a/packages/ui-library/src/components/virtualized-table/index.tsx
+++ b/packages/ui-library/src/components/virtualized-table/index.tsx
@@ -3,6 +3,7 @@ import { Table, TableBody, TableContainer, TableHead, TableRow, Typography, Pape
 import styled from 'styled-components';
 import { TableVirtuoso, TableComponents, ItemContent, ScrollerProps, FixedHeaderContent } from 'react-virtuoso';
 import { colors } from '../../theme';
+import { AnimatedChevronRightIcon } from '../../icons';
 
 const StyledBodySmallRegularTypo2 = styled(Typography).attrs(
   ({
@@ -59,12 +60,18 @@ const StyledBodySmallLabelTypography = styled(Typography).attrs(
   })
 )``;
 
+const StyledRow = styled(TableRow)<{ onClick?: () => void }>`
+  ${({ onClick }) => (!!onClick ? 'cursor: pointer;' : '')}
+  &:hover {
+    ${AnimatedChevronRightIcon} {
+      transition: transform 0.15s ease;
+      transform: translateX(${({ theme }) => theme.spacing(1)});
+    }
+  }
+`;
+
 interface VirtualizedTableContext {
-  rowContext?: {
-    setHovered?: (index?: number) => void;
-    style?: React.CSSProperties;
-    onClick?: (index: number) => void;
-  };
+  onRowClick?: (rowIndex: number) => void;
 }
 
 interface VirtualizedTableProps<Data, Context> {
@@ -92,13 +99,10 @@ function buildVirtuosoTableComponents<D, C extends VirtualizedTableContext>(): T
     }),
     Table: (props) => <Table sx={{ padding: 0 }} {...props} />,
     TableHead,
-    TableRow: ({ item: _item, context, ...props }) => (
-      <TableRow
+    TableRow: ({ item, context, ...props }) => (
+      <StyledRow
+        onClick={context?.onRowClick ? () => context.onRowClick?.(props['data-index']) : undefined}
         {...props}
-        onMouseEnter={() => context?.rowContext?.setHovered && context.rowContext.setHovered(props['data-index'])}
-        onMouseLeave={() => context?.rowContext?.setHovered && context.rowContext.setHovered()}
-        onClick={() => context?.rowContext?.onClick && context.rowContext.onClick(props['data-index'])}
-        style={context?.rowContext?.style}
       />
     ),
     TableBody: forwardRef<HTMLTableSectionElement>(function VirtuosoTableBody(props, ref) {

--- a/packages/ui-library/src/components/virtualized-table/index.tsx
+++ b/packages/ui-library/src/components/virtualized-table/index.tsx
@@ -59,7 +59,13 @@ const StyledBodySmallLabelTypography = styled(Typography).attrs(
   })
 )``;
 
-interface BaseContext {}
+interface BaseContext {
+  rowContext?: {
+    setHovered?: (index?: number) => void;
+    style?: React.CSSProperties;
+    onClick?: (index: number) => void;
+  };
+}
 
 interface VirtualizedTableProps<Data, Context> {
   data: Data[];
@@ -86,7 +92,15 @@ function buildVirtuosoTableComponents<D, C extends BaseContext>(): TableComponen
     }),
     Table: (props) => <Table sx={{ padding: 0 }} {...props} />,
     TableHead,
-    TableRow: ({ item: _item, ...props }) => <TableRow {...props} />,
+    TableRow: ({ item: _item, context, ...props }) => (
+      <TableRow
+        {...props}
+        onMouseEnter={() => context?.rowContext?.setHovered && context.rowContext.setHovered(props['data-index'])}
+        onMouseLeave={() => context?.rowContext?.setHovered && context.rowContext.setHovered()}
+        onClick={() => context?.rowContext?.onClick && context.rowContext.onClick(props['data-index'])}
+        style={context?.rowContext?.style}
+      />
+    ),
     TableBody: forwardRef<HTMLTableSectionElement>(function VirtuosoTableBody(props, ref) {
       return <TableBody {...props} ref={ref} />;
     }),
@@ -125,4 +139,5 @@ export {
   buildVirtuosoTableComponents,
   StyledBodySmallLabelTypography,
   type ItemContent,
+  type BaseContext,
 };

--- a/packages/ui-library/src/icons/animated-chevron-right.tsx
+++ b/packages/ui-library/src/icons/animated-chevron-right.tsx
@@ -8,16 +8,11 @@ const AnimatedChevronRight = styled((props: SvgIconProps) => (
   <ContainerBox alignItems="center" flex={1} justifyContent="center">
     <ChevronRightIcon {...props} sx={{ flex: '1' }} />
   </ContainerBox>
-))<{ $hovered?: boolean; $controlled?: boolean }>`
-  ${({ $hovered, $controlled, theme: { spacing } }) => `
+))<{ $hovered?: boolean }>`
+  ${({ $hovered, theme: { spacing } }) => `
   transition: transform 0.15s ease;
-  ${
-    $controlled
-      ? `transform: translateX(${$hovered ? spacing(1) : 0});`
-      : `&:hover {
-          transform: translateX(${spacing(1)});
-        }`
-  }`}
+  transform: translateX(${$hovered ? spacing(1) : 0});
+  `}
 `;
 
 export default AnimatedChevronRight;


### PR DESCRIPTION
### Fixes addressed in this PR:
- [x] Try to adjust gap between last two X tickers
- [x] Add margin-left to X axis tickers
- [x] Add amountInUnits to portfolio table
- [x] Decimals in Net Worth should have less opacity
- [x] Rename distribution to be Spot and Recurring Investments => Created **`BLY-2952`** for improvement
- [x] Add % to distribution numbers
- [x] The Home menu item is highlighted when token profile page is open
- [x] Remove 100% from portfolio table
- [x] Change Top NetWorth number to be the token price
- [x] Explorer links should take to the address, not the token page => Dismissed
- [x] Set Default graph period to 1 week
- [x] Graph paper color
- [x] DCA is loading all net worth, not filtered by token
- [x] Make full portfolio row clickable and hoverable

### Pending issues:
- [ ] Debug on failed prices from history => Created **`BLY-2955`**
- [ ] Debug old timestamps (LINK from +1 year ago) => Created **`BLY-2953`**

Created and added to **`BLY-2954`**:
- [ ] Add event date to GraphTooltip
- [ ] Improve skeleton loading
- [ ] Below 'All Wallets' we have a border-bottom that shouldn't be there
- [ ] Rows in AllWallets table have a border-radius and they shouldn't
- [ ] Remove border-bottom from last row
- [ ] Add hover to each explorer Chip, like we have in Activity (home)
- [ ] Try to make Y trickers equally distant

