### PR TITLE
feat(design-system): Grid + Responsiveness

### DIFF
--- a/apps/root/src/common/components/timeline-controls/index.tsx
+++ b/apps/root/src/common/components/timeline-controls/index.tsx
@@ -16,13 +16,6 @@ import { FormattedMessage, defineMessage, useIntl } from 'react-intl';
 import PositionTimeline, { PositionTimelineProps } from './timeline';
 import find from 'lodash/find';
 import isUndefined from 'lodash/isUndefined';
-import styled from 'styled-components';
-
-const StyledPaper = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
-  ${({ theme: { spacing } }) => `
-    padding: ${spacing(6)}
-  `}
-`;
 
 export type TimelineItemComponent = {
   transactionData: () => React.ReactElement;
@@ -133,7 +126,7 @@ const PositionTimelineControls = <TAction, TPosition>({
   const shouldUseSelectMenu = useMediaQuery(theme.breakpoints.down('lg'));
 
   return (
-    <StyledPaper>
+    <BackgroundPaper variant="outlined">
       <Grid container rowSpacing={6}>
         <Grid item xs={12} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <Typography variant="bodyBold">
@@ -149,7 +142,7 @@ const PositionTimelineControls = <TAction, TPosition>({
           <PositionTimeline {...timelineProps} />
         </Grid>
       </Grid>
-    </StyledPaper>
+    </BackgroundPaper>
   );
 };
 export default PositionTimelineControls;

--- a/apps/root/src/common/components/timeline-controls/index.tsx
+++ b/apps/root/src/common/components/timeline-controls/index.tsx
@@ -130,7 +130,7 @@ const PositionTimelineControls = <TAction, TPosition>({
   ...timelineProps
 }: PositionTimelineControlsProps<TAction, TPosition>) => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const shouldUseSelectMenu = useMediaQuery(theme.breakpoints.down('lg'));
 
   return (
     <StyledPaper>
@@ -139,7 +139,7 @@ const PositionTimelineControls = <TAction, TPosition>({
           <Typography variant="bodyBold">
             <FormattedMessage description="timeline" defaultMessage="Timeline" />
           </Typography>
-          {isMobile ? (
+          {shouldUseSelectMenu ? (
             <PositionTimelineSelectControl options={options} selected={tabIndex} onSelect={setTabIndex} />
           ) : (
             <PositionTimelineFiltersControl options={options} selected={tabIndex} onSelect={setTabIndex} />

--- a/apps/root/src/common/utils/earn/parsing.tsx
+++ b/apps/root/src/common/utils/earn/parsing.tsx
@@ -240,6 +240,20 @@ export function getComparator<Key extends StrategyColumnKeys, Variant extends St
   };
 }
 
+export const getStrategyFromTableObject = <T extends StrategiesTableVariants>(
+  tableStrategy: TableStrategy<T>,
+  variant: T
+) => {
+  let strategy: Strategy;
+  if (variant === StrategiesTableVariants.ALL_STRATEGIES) {
+    strategy = tableStrategy as Strategy;
+  } else {
+    strategy = (tableStrategy as EarnPosition[])[0].strategy;
+  }
+
+  return strategy;
+};
+
 export enum StrategyReturnPeriods {
   DAY = 'day',
   WEEK = 'week',

--- a/apps/root/src/frame/index.tsx
+++ b/apps/root/src/frame/index.tsx
@@ -58,7 +58,10 @@ const queryClient = new QueryClient();
 
 const StyledAppGridContainer = styled(Grid)`
   ${({ theme: { spacing, breakpoints } }) => `
-    padding-top: ${spacing(breakpoints.down('md') ? 14 : 20)} !important;
+    padding-top: ${spacing(20)} !important;
+    ${breakpoints.down('md')} {
+      padding-top: ${spacing(14)} !important;
+    }
     padding-bottom: ${spacing(10)} !important;
     flex: 1;
     display: flex;

--- a/apps/root/src/frame/index.tsx
+++ b/apps/root/src/frame/index.tsx
@@ -13,7 +13,6 @@ import { hydrateStoreFromSavedConfig, setNetwork } from '@state/config/actions';
 import find from 'lodash/find';
 import useProviderService from '@hooks/useProviderService';
 import ErrorBoundary from '@common/components/error-boundary/indext';
-import useCurrentBreakpoint from '@hooks/useCurrentBreakpoint';
 import '@rainbow-me/rainbowkit/styles.css';
 import CenteredLoadingIndicator from '@common/components/centered-loading-indicator';
 import { useThemeMode } from '@state/config/hooks';
@@ -46,11 +45,11 @@ const StyledGridContainer = styled(Grid)<{ isSmall?: boolean }>`
   position: relative;
   flex: 1;
   max-width: 1160px;
-  ${({ isSmall, theme: { breakpoints, spacing } }) => `
-    ${isSmall && 'margin-bottom: 40px !important;'}
+  ${({ theme: { breakpoints, spacing } }) => `
     ${breakpoints.down('md')} {
       padding: 0px ${spacing(4)};
       max-width: 1080px;
+      margin-bottom: 40px !important;
     }
   `}
 `;
@@ -84,7 +83,6 @@ const AppFrame = ({ config: { wagmiClient } }: AppFrameProps) => {
   const providerService = useProviderService();
   const pairService = usePairService();
   const web3Service = useWeb3Service();
-  const currentBreakPoint = useCurrentBreakpoint();
   const themeMode = useThemeMode();
 
   const dispatch = useAppDispatch();
@@ -122,13 +120,8 @@ const AppFrame = ({ config: { wagmiClient } }: AppFrameProps) => {
                   )}
                   <PromisesInitializer />
                   <Navigation>
-                    <StyledGridContainer
-                      container
-                      direction="row"
-                      justifyContent="center"
-                      isSmall={currentBreakPoint === 'xs'}
-                    >
-                      <StyledAppGridContainer item xs={12} sm={10} md={11} xl={12}>
+                    <StyledGridContainer container direction="row" justifyContent="center">
+                      <StyledAppGridContainer item xs={12} sm={10} lg={11} xl={12}>
                         <ErrorBoundary>
                           <Suspense fallback={<CenteredLoadingIndicator />}>
                             <Routes>

--- a/apps/root/src/pages/aggregator/swap-container/components/swap-settings/components/slippage-input/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/components/swap-settings/components/slippage-input/index.tsx
@@ -41,7 +41,7 @@ const SlippageInput = ({ id, onChange, value }: SlippageInputProps) => {
   }));
 
   return (
-    <ContainerBox gap={4}>
+    <ContainerBox gap={4} flexWrap="wrap">
       <TextField
         id={id}
         placeholder={intl.formatMessage(

--- a/apps/root/src/pages/aggregator/swap-container/components/swap-settings/index.tsx
+++ b/apps/root/src/pages/aggregator/swap-container/components/swap-settings/index.tsx
@@ -111,6 +111,7 @@ const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   paddingTop: theme.spacing(3),
   marginTop: 0,
   borderTop: 'none',
+  overflowY: 'scroll',
 }));
 
 const StyledApprovalContainer = styled(BackgroundPaper).attrs({ variant: 'outlined' })`

--- a/apps/root/src/pages/dca/positions/components/dashboard/index.tsx
+++ b/apps/root/src/pages/dca/positions/components/dashboard/index.tsx
@@ -6,7 +6,7 @@ import UsdDashboard from '../usd-dashboard';
 const PositionDashboard = () => {
   return (
     <BackgroundPaper variant="outlined">
-      <Grid container columnSpacing={12} alignItems="stretch">
+      <Grid container columnSpacing={8} alignItems="stretch">
         <Grid item xs={12} md={5}>
           <CountDashboard />
         </Grid>

--- a/apps/root/src/pages/dca/positions/components/positions-list/current-positions/index.tsx
+++ b/apps/root/src/pages/dca/positions/components/positions-list/current-positions/index.tsx
@@ -243,17 +243,17 @@ const CurrentPositions = ({ isLoading }: CurrentPositionsProps) => {
       <Grid container spacing={8}>
         {!!sortedPositions.length && (
           <>
-            <StyledGridItem item xs={12} sm={6}>
+            <StyledGridItem item xs={12} md={6}>
               <CreatePositionBox />
             </StyledGridItem>
             {isLoading
               ? skeletonItems.map((i) => (
-                  <StyledGridItem item xs={12} sm={6} key={i}>
+                  <StyledGridItem item xs={12} md={6} key={i}>
                     <PositionCardSkeleton />
                   </StyledGridItem>
                 ))
               : sortedPositions.map((position) => (
-                  <StyledGridItem item xs={12} sm={6} key={position.id}>
+                  <StyledGridItem item xs={12} md={6} key={position.id}>
                     <OpenPosition
                       position={position}
                       onWithdraw={onWithdraw}

--- a/apps/root/src/pages/earn/components/strategies-display-wrapper/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-display-wrapper/index.tsx
@@ -58,8 +58,6 @@ const StrategiesDisplayWrapper = <T extends StrategiesTableVariants>({
     [page, strategies]
   );
 
-  const displayColumns = columns.filter((col) => !col.hidden?.(theme));
-
   return (
     <ContainerBox flexDirection="column" gap={5} flex={1}>
       <AllStrategiesTableToolbar
@@ -80,7 +78,7 @@ const StrategiesDisplayWrapper = <T extends StrategiesTableVariants>({
         />
       ) : (
         <StrategiesTable
-          displayColumns={displayColumns}
+          columns={columns}
           visibleRows={visibleRows}
           variant={variant}
           isLoading={isLoading}

--- a/apps/root/src/pages/earn/components/strategies-display-wrapper/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-display-wrapper/index.tsx
@@ -1,0 +1,99 @@
+import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
+import React from 'react';
+import { ContainerBox, useMediaQuery } from 'ui-library';
+import { StrategyColumnConfig } from '../strategies-table/components/columns';
+import StrategiesTable, { TableStrategy } from '../strategies-table';
+import StrategiesList from '../strategies-list';
+import usePushToHistory from '@hooks/usePushToHistory';
+import useTrackEvent from '@hooks/useTrackEvent';
+import { useAppDispatch } from '@state/hooks';
+import { useTheme } from 'styled-components';
+import { Strategy } from 'common-types';
+import { debounce } from 'lodash';
+import { setSearch } from '@state/strategies-filters/actions';
+import AllStrategiesTableToolbar from '../strategies-table/components/toolbar';
+
+const ROWS_PER_PAGE = 7;
+
+interface StrategiesTableProps<T extends StrategiesTableVariants> {
+  columns: StrategyColumnConfig<T>[];
+  strategies: TableStrategy<T>[];
+  variant: T;
+  isLoading: boolean;
+  showTotal?: boolean;
+}
+
+const StrategiesDisplayWrapper = <T extends StrategiesTableVariants>({
+  columns,
+  strategies,
+  isLoading,
+  variant,
+  showTotal = false,
+}: StrategiesTableProps<T>) => {
+  const [page, setPage] = React.useState(0);
+  const pushToHistory = usePushToHistory();
+  const trackEvent = useTrackEvent();
+  const dispatch = useAppDispatch();
+  const theme = useTheme();
+
+  const shouldShowMobileList = useMediaQuery(theme.breakpoints.down('md'));
+
+  const onGoToStrategy = React.useCallback(
+    (strategy: Strategy) => {
+      pushToHistory(`/earn/vaults/${strategy.network.chainId}/${strategy.id}`);
+      trackEvent('Earn Vault List - Go to vault details', {
+        chainId: strategy.network.chainId,
+      });
+    },
+    [pushToHistory, trackEvent]
+  );
+
+  const handleSearchChange = debounce((newValue: string) => {
+    setPage(0);
+    dispatch(setSearch({ variant, value: newValue }));
+  }, 500);
+
+  const visibleRows = React.useMemo(
+    () => strategies.slice(page * ROWS_PER_PAGE, page * ROWS_PER_PAGE + ROWS_PER_PAGE),
+    [page, strategies]
+  );
+
+  const displayColumns = columns.filter((col) => !col.hidden?.(theme));
+
+  return (
+    <ContainerBox flexDirection="column" gap={5} flex={1}>
+      <AllStrategiesTableToolbar
+        strategiesCount={strategies.length}
+        isLoading={isLoading}
+        handleSearchChange={handleSearchChange}
+        variant={variant}
+      />
+      {shouldShowMobileList ? (
+        <StrategiesList
+          totalCount={strategies.length}
+          rowsPerPage={ROWS_PER_PAGE}
+          page={page}
+          setPage={setPage}
+          variant={variant}
+          visibleStrategies={visibleRows}
+          isLoading={isLoading}
+        />
+      ) : (
+        <StrategiesTable
+          displayColumns={displayColumns}
+          visibleRows={visibleRows}
+          variant={variant}
+          isLoading={isLoading}
+          showTotal={showTotal}
+          onGoToStrategy={onGoToStrategy}
+          rowsPerPage={ROWS_PER_PAGE}
+          page={page}
+          setPage={setPage}
+          strategies={strategies}
+        />
+      )}
+    </ContainerBox>
+  );
+};
+
+export default StrategiesDisplayWrapper;

--- a/apps/root/src/pages/earn/components/strategies-list/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-list/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Grid, TablePagination } from 'ui-library';
+import { TableStrategy } from '../strategies-table';
+import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
+import { SetStateCallback } from 'common-types';
+import StrategyCardItem from '../strategy-card-item';
+import { getStrategyFromTableObject } from '@common/utils/earn/parsing';
+
+interface StrategiesListProps<T extends StrategiesTableVariants> {
+  visibleStrategies: TableStrategy<T>[];
+  totalCount: number;
+  rowsPerPage: number;
+  page: number;
+  setPage: SetStateCallback<number>;
+  variant: StrategiesTableVariants;
+  isLoading: boolean;
+}
+
+const skeletonRows = Array.from(Array(4).keys());
+
+const StrategiesList = <T extends StrategiesTableVariants>({
+  visibleStrategies,
+  totalCount,
+  page,
+  rowsPerPage,
+  setPage,
+  variant,
+  isLoading,
+}: StrategiesListProps<T>) => (
+  <Grid container spacing={6}>
+    {isLoading
+      ? skeletonRows.map((index) => (
+          <Grid item xs={12} md={6} key={index}>
+            <StrategyCardItem.Skeleton />
+          </Grid>
+        ))
+      : visibleStrategies.map((tableStrategy, index) => (
+          <Grid item xs={12} md={6} key={index}>
+            <StrategyCardItem strategy={getStrategyFromTableObject(tableStrategy, variant)} />
+          </Grid>
+        ))}
+    <Grid item xs={12}>
+      <TablePagination
+        count={totalCount}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={(_, newPage) => setPage(newPage)}
+      />
+    </Grid>
+  </Grid>
+);
+
+export default StrategiesList;

--- a/apps/root/src/pages/earn/components/strategies-table/components/columns/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-table/components/columns/index.tsx
@@ -7,12 +7,13 @@ import ComposedTokenIcon from '@common/components/composed-token-icon';
 import { usdFormatter } from '@common/utils/parsing';
 import { emptyTokenWithLogoURI } from '@common/utils/currency';
 import { getStrategySafetyIcon, parseUserStrategiesFinancialData } from '@common/utils/earn/parsing';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
 import { Address as ViemAddress } from 'viem';
 import Address from '@common/components/address';
 import { useThemeMode } from '@state/config/hooks';
 import { StrategyRiskLevel } from 'common-types';
+import TokenIconWithNetwork from '@common/components/token-icon-with-network';
 
 export enum StrategyColumnKeys {
   VAULT_NAME = 'vaultName',
@@ -97,7 +98,7 @@ export interface StrategyColumnConfig<T extends StrategiesTableVariants> {
   renderCell: (data: TableStrategy<T>) => React.ReactNode | string;
   getOrderValue?: (data: TableStrategy<T>) => string | number | undefined;
   customSkeleton?: React.ReactNode;
-  hidden?: boolean;
+  hidden?: (theme: ReturnType<typeof useTheme>) => boolean;
 }
 
 export const strategyColumnConfigs: StrategyColumnConfig<StrategiesTableVariants.ALL_STRATEGIES>[] = [
@@ -135,7 +136,7 @@ export const strategyColumnConfigs: StrategyColumnConfig<StrategiesTableVariants
     ),
     renderCell: () => <></>,
     getOrderValue: (data) => (data.walletBalance ? data.walletBalance.amountInUSD || '0' : undefined),
-    hidden: true,
+    hidden: () => true,
   },
   {
     key: StrategyColumnKeys.REWARDS,
@@ -167,6 +168,7 @@ export const strategyColumnConfigs: StrategyColumnConfig<StrategiesTableVariants
         </StyledBoxedLabel>
       </ContainerBox>
     ),
+    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
   },
   {
     key: StrategyColumnKeys.TVL,
@@ -219,6 +221,19 @@ export const portfolioColumnConfigs: StrategyColumnConfig<StrategiesTableVariant
     getOrderValue: (data) => data[0].strategy.farm.name,
   },
   {
+    // Token column for smaller screens
+    key: StrategyColumnKeys.TOKEN,
+    label: <FormattedMessage description="earn.all-strategies-table.column.token" defaultMessage="Token" />,
+    renderCell: (data) => <TokenIconWithNetwork token={data[0].strategy.asset} />,
+    customSkeleton: (
+      <ContainerBox gap={2} alignItems="center">
+        <Skeleton variant="circular" width={28} height={28} animation="wave" />
+      </ContainerBox>
+    ),
+    hidden: (theme) => window.innerWidth >= theme.breakpoints.values.lg,
+  },
+  {
+    // Token column for larger screens
     key: StrategyColumnKeys.TOKEN,
     label: <FormattedMessage description="earn.all-strategies-table.column.token" defaultMessage="Token" />,
     renderCell: (data) => (
@@ -235,17 +250,20 @@ export const portfolioColumnConfigs: StrategyColumnConfig<StrategiesTableVariant
         </StyledBodySmallRegularTypo2>
       </ContainerBox>
     ),
+    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
   },
   {
     key: StrategyColumnKeys.REWARDS,
     label: <FormattedMessage description="earn.all-strategies-table.column.rewards" defaultMessage="Rewards" />,
     renderCell: (data) => <ComposedTokenIcon tokens={data[0].strategy.rewards.tokens} size={4.5} />,
+    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
   },
   {
     key: StrategyColumnKeys.CHAIN_NAME,
     label: <FormattedMessage description="earn.all-strategies-table.column.chain" defaultMessage="Chain" />,
     renderCell: (data) => data[0].strategy.network.name,
     getOrderValue: (data) => data[0].strategy.network.name,
+    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
   },
   {
     key: StrategyColumnKeys.APY,

--- a/apps/root/src/pages/earn/components/strategies-table/components/columns/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-table/components/columns/index.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { TableStrategy } from '../..';
-import { ContainerBox, Skeleton, StyledBodySmallRegularTypo2, Tooltip, Typography, colors } from 'ui-library';
+import {
+  ContainerBox,
+  HiddenProps,
+  Skeleton,
+  StyledBodySmallRegularTypo2,
+  Tooltip,
+  Typography,
+  colors,
+} from 'ui-library';
 import TokenIcon from '@common/components/token-icon';
 import ComposedTokenIcon from '@common/components/composed-token-icon';
 import { usdFormatter } from '@common/utils/parsing';
 import { emptyTokenWithLogoURI } from '@common/utils/currency';
 import { getStrategySafetyIcon, parseUserStrategiesFinancialData } from '@common/utils/earn/parsing';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
 import { Address as ViemAddress } from 'viem';
 import Address from '@common/components/address';
@@ -98,7 +106,7 @@ export interface StrategyColumnConfig<T extends StrategiesTableVariants> {
   renderCell: (data: TableStrategy<T>) => React.ReactNode | string;
   getOrderValue?: (data: TableStrategy<T>) => string | number | undefined;
   customSkeleton?: React.ReactNode;
-  hidden?: (theme: ReturnType<typeof useTheme>) => boolean;
+  hiddenProps?: HiddenProps;
 }
 
 export const strategyColumnConfigs: StrategyColumnConfig<StrategiesTableVariants.ALL_STRATEGIES>[] = [
@@ -136,7 +144,9 @@ export const strategyColumnConfigs: StrategyColumnConfig<StrategiesTableVariants
     ),
     renderCell: () => <></>,
     getOrderValue: (data) => (data.walletBalance ? data.walletBalance.amountInUSD || '0' : undefined),
-    hidden: () => true,
+    hiddenProps: {
+      xsUp: true,
+    },
   },
   {
     key: StrategyColumnKeys.REWARDS,
@@ -168,7 +178,9 @@ export const strategyColumnConfigs: StrategyColumnConfig<StrategiesTableVariants
         </StyledBoxedLabel>
       </ContainerBox>
     ),
-    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
+    hiddenProps: {
+      lgDown: true,
+    },
   },
   {
     key: StrategyColumnKeys.TVL,
@@ -224,13 +236,19 @@ export const portfolioColumnConfigs: StrategyColumnConfig<StrategiesTableVariant
     // Token column for smaller screens
     key: StrategyColumnKeys.TOKEN,
     label: <FormattedMessage description="earn.all-strategies-table.column.token" defaultMessage="Token" />,
-    renderCell: (data) => <TokenIconWithNetwork token={data[0].strategy.asset} />,
+    renderCell: (data) => (
+      <ContainerBox>
+        <TokenIconWithNetwork token={data[0].strategy.asset} />
+      </ContainerBox>
+    ),
     customSkeleton: (
       <ContainerBox gap={2} alignItems="center">
         <Skeleton variant="circular" width={28} height={28} animation="wave" />
       </ContainerBox>
     ),
-    hidden: (theme) => window.innerWidth >= theme.breakpoints.values.lg,
+    hiddenProps: {
+      lgUp: true,
+    },
   },
   {
     // Token column for larger screens
@@ -250,20 +268,26 @@ export const portfolioColumnConfigs: StrategyColumnConfig<StrategiesTableVariant
         </StyledBodySmallRegularTypo2>
       </ContainerBox>
     ),
-    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
+    hiddenProps: {
+      lgDown: true,
+    },
   },
   {
     key: StrategyColumnKeys.REWARDS,
     label: <FormattedMessage description="earn.all-strategies-table.column.rewards" defaultMessage="Rewards" />,
     renderCell: (data) => <ComposedTokenIcon tokens={data[0].strategy.rewards.tokens} size={4.5} />,
-    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
+    hiddenProps: {
+      lgDown: true,
+    },
   },
   {
     key: StrategyColumnKeys.CHAIN_NAME,
     label: <FormattedMessage description="earn.all-strategies-table.column.chain" defaultMessage="Chain" />,
     renderCell: (data) => data[0].strategy.network.name,
     getOrderValue: (data) => data[0].strategy.network.name,
-    hidden: (theme) => window.innerWidth < theme.breakpoints.values.lg,
+    hiddenProps: {
+      lgDown: true,
+    },
   },
   {
     key: StrategyColumnKeys.APY,

--- a/apps/root/src/pages/earn/components/strategies-table/components/toolbar/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-table/components/toolbar/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useThemeMode } from '@state/config/hooks';
 import { FormattedMessage, defineMessage, useIntl } from 'react-intl';
 import { ContainerBox, InputAdornment, SearchIcon, TextField, Typography, colors } from 'ui-library';
 import TableFilters from '../filters';
@@ -9,22 +8,45 @@ interface AllStrategiesTableToolbarProps {
   isLoading: boolean;
   handleSearchChange: (search: string) => void;
   variant: StrategiesTableVariants;
+  strategiesCount: number;
 }
 
-const AllStrategiesTableToolbar = ({ isLoading, handleSearchChange, variant }: AllStrategiesTableToolbarProps) => {
+const AllStrategiesTableToolbar = ({
+  isLoading,
+  handleSearchChange,
+  variant,
+  strategiesCount,
+}: AllStrategiesTableToolbarProps) => {
   const intl = useIntl();
-  const themeMode = useThemeMode();
 
   return (
-    <ContainerBox justifyContent="space-between" alignItems="end">
+    <ContainerBox justifyContent="space-between" alignItems="end" flexWrap="wrap" gap={3}>
       {variant === StrategiesTableVariants.ALL_STRATEGIES ? (
-        <Typography variant="h2Bold" color={colors[themeMode].typography.typo1}>
+        <Typography variant="h2Bold" color={({ palette: { mode } }) => colors[mode].typography.typo1}>
           <FormattedMessage description="earn.all-strategies-table.title" defaultMessage="All Vaults" />
         </Typography>
       ) : (
-        <Typography variant="h3Bold" color={colors[themeMode].typography.typo1}>
-          <FormattedMessage description="earn.user-strategies-table.title" defaultMessage="Active Vaults" />
-        </Typography>
+        <ContainerBox alignItems="center" gap={2}>
+          <Typography variant="h3Bold" color={({ palette: { mode } }) => colors[mode].typography.typo1}>
+            <FormattedMessage description="earn.user-strategies-table.title" defaultMessage="Active Vaults" />
+          </Typography>
+          <Typography variant="bodySmallRegular">
+            {' · '}
+            {strategiesCount === 1 ? (
+              <FormattedMessage
+                description="earn.user-strategies-table.active-strategies-amount"
+                defaultMessage="{amount} Investment"
+                values={{ amount: strategiesCount }}
+              />
+            ) : (
+              <FormattedMessage
+                description="earn.user-strategies-table.active-strategies-amount.plural"
+                defaultMessage="{amount} Investments"
+                values={{ amount: strategiesCount }}
+              />
+            )}
+          </Typography>
+        </ContainerBox>
       )}
       <ContainerBox gap={6}>
         <TextField

--- a/apps/root/src/pages/earn/components/strategies-table/index.tsx
+++ b/apps/root/src/pages/earn/components/strategies-table/index.tsx
@@ -19,6 +19,7 @@ import {
   colors,
   DividerBorder1,
   Typography,
+  Hidden,
 } from 'ui-library';
 import styled from 'styled-components';
 import { useAppDispatch } from '@state/hooks';
@@ -93,20 +94,22 @@ const StrategiesTableHeader = <T extends StrategiesTableVariants>({
     <TableHead>
       <TableRow>
         {columns.map((column) => (
-          <StyledTableCell key={column.key} sortDirection={orderBy.column === column.key ? orderBy.order : false}>
-            {column.getOrderValue ? (
-              <TableSortLabel
-                active={orderBy.column === column.key}
-                direction={orderBy.column === column.key ? orderBy.order : 'asc'}
-                onClick={() => onRequestSort(column.key)}
-                hideSortIcon
-              >
+          <Hidden {...column.hiddenProps} key={column.key}>
+            <StyledTableCell key={column.key} sortDirection={orderBy.column === column.key ? orderBy.order : false}>
+              {column.getOrderValue ? (
+                <TableSortLabel
+                  active={orderBy.column === column.key}
+                  direction={orderBy.column === column.key ? orderBy.order : 'asc'}
+                  onClick={() => onRequestSort(column.key)}
+                  hideSortIcon
+                >
+                  <StyledBodySmallLabelTypography>{column.label}</StyledBodySmallLabelTypography>
+                </TableSortLabel>
+              ) : (
                 <StyledBodySmallLabelTypography>{column.label}</StyledBodySmallLabelTypography>
-              </TableSortLabel>
-            ) : (
-              <StyledBodySmallLabelTypography>{column.label}</StyledBodySmallLabelTypography>
-            )}
-          </StyledTableCell>
+              )}
+            </StyledTableCell>
+          </Hidden>
         ))}
         <StyledTableEnd size="small"></StyledTableEnd>
       </TableRow>
@@ -163,9 +166,11 @@ const Row = <T extends StrategiesTableVariants>({ columns, rowData, onRowClick, 
       onClick={() => onRowClick(strategy)}
     >
       {columns.map((column) => (
-        <StyledTableCell key={`${strategy.id}-${column.key}`}>
-          {renderBodyCell(column.renderCell(rowData))}
-        </StyledTableCell>
+        <Hidden {...column.hiddenProps} key={`${strategy.id}-${column.key}`}>
+          <StyledTableCell key={`${strategy.id}-${column.key}`}>
+            {renderBodyCell(column.renderCell(rowData))}
+          </StyledTableCell>
+        </Hidden>
       ))}
       <StyledTableEnd size="small">
         <StyledNavContainer alignItems="center">
@@ -221,16 +226,18 @@ const TotalRow = <T extends StrategiesTableVariants>({ columns, strategies, vari
         </Typography>
       </StyledTableCell>
       {columns.slice(1).map((column) => (
-        <StyledTableCell key={column.key}>
-          {column.key === StrategyColumnKeys.TOTAL_INVESTED ? (
-            <Typography variant="bodyBold">{`$${usdFormatter(totalInvested.totalInvestedUsd)}`}</Typography>
-          ) : null}
-          {column.key === StrategyColumnKeys.CURRENT_PROFIT ? (
-            <Typography variant="bodyBold" color="success.dark">
-              +{usdFormatter(totalInvested.currentProfitUsd)}
-            </Typography>
-          ) : null}
-        </StyledTableCell>
+        <Hidden {...column.hiddenProps} key={column.key}>
+          <StyledTableCell key={column.key}>
+            {column.key === StrategyColumnKeys.TOTAL_INVESTED ? (
+              <Typography variant="bodyBold">{`$${usdFormatter(totalInvested.totalInvestedUsd)}`}</Typography>
+            ) : null}
+            {column.key === StrategyColumnKeys.CURRENT_PROFIT ? (
+              <Typography variant="bodyBold" color="success.dark">
+                +{usdFormatter(totalInvested.currentProfitUsd)}
+              </Typography>
+            ) : null}
+          </StyledTableCell>
+        </Hidden>
       ))}
       <StyledDividerContainer flexDirection="column" fullWidth>
         <DividerBorder1 />
@@ -240,7 +247,7 @@ const TotalRow = <T extends StrategiesTableVariants>({ columns, strategies, vari
 };
 
 interface StrategiesTableProps<T extends StrategiesTableVariants> {
-  displayColumns: StrategyColumnConfig<T>[];
+  columns: StrategyColumnConfig<T>[];
   visibleRows: TableStrategy<T>[];
   variant: T;
   isLoading: boolean;
@@ -253,7 +260,7 @@ interface StrategiesTableProps<T extends StrategiesTableVariants> {
 }
 
 const StrategiesTable = <T extends StrategiesTableVariants>({
-  displayColumns,
+  columns,
   visibleRows,
   variant,
   isLoading,
@@ -270,17 +277,17 @@ const StrategiesTable = <T extends StrategiesTableVariants>({
   return (
     <TableContainer component={StyledBackgroundPaper}>
       <Table sx={{ tableLayout: 'auto' }}>
-        <StrategiesTableHeader columns={displayColumns} variant={variant} />
+        <StrategiesTableHeader columns={columns} variant={variant} />
         <TableBody>
           {isLoading ? (
-            <AllStrategiesTableBodySkeleton columns={displayColumns} rowsPerPage={rowsPerPage} />
+            <AllStrategiesTableBodySkeleton columns={columns} rowsPerPage={rowsPerPage} />
           ) : (
             <>
               {visibleRows.map((row, index) => (
-                <Row key={index} columns={displayColumns} rowData={row} onRowClick={onGoToStrategy} variant={variant} />
+                <Row key={index} columns={columns} rowData={row} onRowClick={onGoToStrategy} variant={variant} />
               ))}
               {emptyRows}
-              {showTotal && <TotalRow columns={displayColumns} variant={variant} strategies={strategies} />}
+              {showTotal && <TotalRow columns={columns} variant={variant} strategies={strategies} />}
             </>
           )}
         </TableBody>

--- a/apps/root/src/pages/earn/components/strategy-card-item/index.tsx
+++ b/apps/root/src/pages/earn/components/strategy-card-item/index.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Strategy } from 'common-types';
+import styled from 'styled-components';
+import { Button, ContainerBox, Typography, colors, Card, AnimatedChevronRightIcon, Skeleton } from 'ui-library';
+import DataCards, { DataCardVariants } from '@pages/strategy-guardian-detail/vault-data/components/data-cards';
+import TokenIconWithNetwork from '@common/components/token-icon-with-network';
+import { FormattedMessage } from 'react-intl';
+import usePushToHistory from '@hooks/usePushToHistory';
+import ComposedTokenIcon from '@common/components/composed-token-icon';
+
+interface SugestedStrategyCardProps {
+  strategy: Strategy;
+  variant?: DataCardVariants;
+}
+
+const StyledCard = styled(Card).attrs({ variant: 'outlined' })`
+  ${({ theme: { palette, spacing } }) => `
+      padding: ${spacing(6)};
+      box-shadow: ${colors[palette.mode].dropShadow.dropShadow300};
+    `}
+`;
+
+const StrategyCardItem = ({ strategy, variant }: SugestedStrategyCardProps) => {
+  const pushToHistory = usePushToHistory();
+  const [hovered, setHovered] = React.useState(false);
+  const handleViewStrategy = () => {
+    pushToHistory(`/earn/vaults/${strategy.network.chainId}/${strategy.id}`);
+  };
+
+  return (
+    <StyledCard>
+      <ContainerBox flexDirection="column" alignItems="stretch" gap={5}>
+        <ContainerBox justifyContent="space-between" alignItems="center">
+          <ContainerBox gap={2} alignItems="center">
+            <TokenIconWithNetwork token={strategy.asset} />
+            <Typography variant="bodySemibold">{strategy.asset.symbol}</Typography>
+            {strategy.rewards.tokens.length > 0 && (
+              <>
+                {` · `}
+                <Typography variant="bodyRegular">
+                  <FormattedMessage description="earn.strategy-card.rewards" defaultMessage="Rewards" />
+                </Typography>
+                <ComposedTokenIcon size={8} tokens={strategy.rewards.tokens} />
+              </>
+            )}
+          </ContainerBox>
+          <Typography variant="bodySmallRegular">{strategy.farm.name}</Typography>
+        </ContainerBox>
+        <DataCards strategy={strategy} dataCardsGap={2} variant={variant} />
+        <ContainerBox fullWidth justifyContent="center">
+          <Button
+            variant="text"
+            color="primary"
+            onClick={handleViewStrategy}
+            fullWidth
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            endIcon={<AnimatedChevronRightIcon $hovered={hovered} color="primary" />}
+          >
+            <FormattedMessage description="earn.strategy-card.button" defaultMessage="View Vault" />
+          </Button>
+        </ContainerBox>
+      </ContainerBox>
+    </StyledCard>
+  );
+};
+
+const SkeletonStrategyCardItem = () => (
+  <StyledCard>
+    <ContainerBox flexDirection="column" alignItems="stretch" gap={5}>
+      <ContainerBox justifyContent="space-between" alignItems="center">
+        <ContainerBox gap={2} alignItems="center">
+          <Skeleton variant="circular" width={32} height={32} />
+          <Typography variant="bodySemibold">
+            <Skeleton width="6ch" variant="text" />
+          </Typography>
+          <Typography variant="bodyRegular">
+            <Skeleton width="6ch" variant="text" />
+          </Typography>
+          <Skeleton variant="circular" width={32} height={32} />
+        </ContainerBox>
+        <Typography variant="bodySmallRegular">
+          <Skeleton width="100%" variant="text" />
+        </Typography>
+      </ContainerBox>
+      <DataCards dataCardsGap={2} variant={DataCardVariants.Home} />
+      <ContainerBox fullWidth justifyContent="center">
+        <Button variant="text" color="primary" fullWidth disabled>
+          <Skeleton width={80} />
+        </Button>
+      </ContainerBox>
+    </ContainerBox>
+  </StyledCard>
+);
+
+StrategyCardItem.Skeleton = SkeletonStrategyCardItem;
+
+export default StrategyCardItem;

--- a/apps/root/src/pages/earn/home/components/all-strategies-table/index.tsx
+++ b/apps/root/src/pages/earn/home/components/all-strategies-table/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import StrategiesTable from '@pages/earn/components/strategies-table';
+import StrategiesDisplayWrapper from '@pages/earn/components/strategies-display-wrapper';
 import { strategyColumnConfigs } from '@pages/earn/components/strategies-table/components/columns';
 import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
 import useHasFetchedAllStrategies from '@hooks/earn/useHasFetchedAllStrategies';
@@ -15,7 +15,7 @@ const AllStrategiesTable = () => {
   const filteredStrategies = useFilteredStrategies({ variant, strategies, columns: strategyColumnConfigs });
 
   return (
-    <StrategiesTable
+    <StrategiesDisplayWrapper
       columns={strategyColumnConfigs}
       variant={variant}
       strategies={filteredStrategies}

--- a/apps/root/src/pages/earn/home/components/wizard/components/suggested-strategies/index.tsx
+++ b/apps/root/src/pages/earn/home/components/wizard/components/suggested-strategies/index.tsx
@@ -1,80 +1,11 @@
 import React from 'react';
-import { Strategy, Token } from 'common-types';
-import styled from 'styled-components';
-import {
-  Button,
-  ContainerBox,
-  Grid,
-  Typography,
-  colors,
-  StarEmoji,
-  Grow,
-  Card,
-  AnimatedChevronRightIcon,
-} from 'ui-library';
-import DataCards, { DataCardVariants } from '@pages/strategy-guardian-detail/vault-data/components/data-cards';
-import TokenIconWithNetwork from '@common/components/token-icon-with-network';
+import { Token } from 'common-types';
+import { ContainerBox, Grid, Typography, colors, StarEmoji, Grow } from 'ui-library';
 import { FormattedMessage } from 'react-intl';
-import usePushToHistory from '@hooks/usePushToHistory';
 import { useThemeMode } from '@state/config/hooks';
 import useSuggestedStrategies from '@hooks/earn/useSuggestedStrategies';
-import ComposedTokenIcon from '@common/components/composed-token-icon';
-
-interface SugestedStrategyCardProps {
-  strategy: Strategy;
-}
-
-const StyledCard = styled(Card).attrs({ variant: 'outlined' })`
-  ${({ theme: { palette, spacing } }) => `
-    padding: ${spacing(6)};
-    box-shadow: ${colors[palette.mode].dropShadow.dropShadow300};
-  `}
-`;
-
-const SuggestedStrategyCard = ({ strategy }: SugestedStrategyCardProps) => {
-  const pushToHistory = usePushToHistory();
-  const [hovered, setHovered] = React.useState(false);
-  const handleViewStrategy = () => {
-    pushToHistory(`/earn/vaults/${strategy.network.chainId}/${strategy.id}`);
-  };
-
-  return (
-    <StyledCard>
-      <ContainerBox flexDirection="column" alignItems="stretch" gap={5}>
-        <ContainerBox justifyContent="space-between" alignItems="center">
-          <ContainerBox gap={2} alignItems="center">
-            <TokenIconWithNetwork token={strategy.asset} />
-            <Typography variant="bodySemibold">{strategy.asset.symbol}</Typography>
-            {strategy.rewards.tokens.length > 0 && (
-              <>
-                {` · `}
-                <Typography variant="bodyRegular">
-                  <FormattedMessage description="earn.wizard.suggestedStrategies.rewards" defaultMessage="Rewards" />
-                </Typography>
-                <ComposedTokenIcon size={8} tokens={strategy.rewards.tokens} />
-              </>
-            )}
-          </ContainerBox>
-          <Typography variant="bodySmallRegular">{strategy.farm.name}</Typography>
-        </ContainerBox>
-        <DataCards strategy={strategy} dataCardsGap={2} variant={DataCardVariants.Wizard} />
-        <ContainerBox fullWidth justifyContent="center">
-          <Button
-            variant="text"
-            color="primary"
-            onClick={handleViewStrategy}
-            fullWidth
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-            endIcon={<AnimatedChevronRightIcon $hovered={hovered} color="primary" />}
-          >
-            <FormattedMessage description="earn.wizard.suggestedStrategies.button" defaultMessage="View Vault" />
-          </Button>
-        </ContainerBox>
-      </ContainerBox>
-    </StyledCard>
-  );
-};
+import StrategyCardItem from '@pages/earn/components/strategy-card-item';
+import { DataCardVariants } from '@pages/strategy-guardian-detail/vault-data/components/data-cards';
 
 interface SuggestedStrategiesProps {
   selectedAsset: {
@@ -101,7 +32,7 @@ const SuggestedStrategies = ({ selectedAsset, selectedReward }: SuggestedStrateg
         {suggested.slice(0, 3).map((strategy, index) => (
           <Grow in timeout={(index + 1) * 1000} key={strategy.id}>
             <Grid item xs={12} md={6} xl={4}>
-              <SuggestedStrategyCard strategy={strategy} />
+              <StrategyCardItem strategy={strategy} variant={DataCardVariants.Home} />
             </Grid>
           </Grow>
         ))}

--- a/apps/root/src/pages/earn/home/components/wizard/components/wizard-selection/index.tsx
+++ b/apps/root/src/pages/earn/home/components/wizard/components/wizard-selection/index.tsx
@@ -17,16 +17,29 @@ import useReplaceHistory from '@hooks/useReplaceHistory';
 import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
 import useHasFetchedAllStrategies from '@hooks/earn/useHasFetchedAllStrategies';
 
-const StyledSelectionContainer = styled(ContainerBox).attrs({
-  justifyContent: 'center',
+const StyledWizardBaseContainer = styled(ContainerBox).attrs({
   alignItems: 'center',
   gap: 3,
+  flexWrap: 'wrap',
+})`
+  ${({ theme: { spacing, breakpoints } }) => `
+    ${breakpoints.down('lg')} {
+      gap: ${spacing(2)};
+    }
+`}
+`;
+
+const StyledSelectionContainer = styled(StyledWizardBaseContainer).attrs({
+  justifyContent: 'center',
   fullWidth: true,
 })`
-  ${({ theme: { palette, spacing, space } }) => `
-      padding: ${space.s04} 0;
+  ${({ theme: { palette, spacing, space, breakpoints } }) => `
+      padding: ${space.s04};
       border: 1px solid ${colors[palette.mode].earnWizard.border};
       border-radius: ${spacing(3)};
+      ${breakpoints.down('md')} {
+        justify-content: start;
+      }
     `}
 `;
 
@@ -164,72 +177,76 @@ export const WizardSelection = ({
 
   return (
     <StyledSelectionContainer>
-      <StyledTitle>
-        <FormattedMessage description="earn.wizard.title-first-part" defaultMessage="I have" />
-      </StyledTitle>
-      <ContainerBox>
-        <Select
-          id="select-wizard-asset"
-          options={assetOptions}
-          RenderItem={TokenSelectorItem}
-          RenderSelectedValue={RenderSelectedValue}
-          selectedItem={selectedAsset}
-          SkeletonItem={SkeletonTokenSelectorItem}
-          onChange={handleAssetChange}
-          disabledSearch
-          limitHeight
-          variant="standard"
-          Header={{
-            component: HeaderItem,
-            props: {
-              label: intl.formatMessage(
-                defineMessage({
-                  defaultMessage: 'All wallets',
-                  description: 'earn.wizard.first-part.all-wallets',
-                })
-              ),
-              Icon: MoneysIcon,
-              secondaryLabel: capitalize(firstDropdownText),
-            },
-          }}
-          isLoading={isLoading}
-          placeholder={firstDropdownText}
-          placeholderProps={{
-            variant: 'h3Bold',
-            color: 'primary',
-          }}
-        />
-      </ContainerBox>
-      <StyledTitle>
-        <FormattedMessage description="earn.wizard.title-second-part" defaultMessage="and I want to generate" />
-      </StyledTitle>
-      <ContainerBox>
-        <Select
-          id="select-wizard-reward"
-          options={rewardOptions}
-          RenderItem={TokenSelectorItem}
-          RenderSelectedValue={RenderSelectedValue}
-          selectedItem={selectedReward}
-          SkeletonItem={SkeletonTokenSelectorItem}
-          onChange={handleRewardChange}
-          disabledSearch
-          limitHeight
-          variant="standard"
-          Header={{
-            component: HeaderItem,
-            props: {
-              label: capitalize(secondDropdownText),
-              Icon: Money4Icon,
-            },
-          }}
-          isLoading={isLoading}
-          placeholder={secondDropdownText}
-          placeholderProps={{
-            variant: 'h3Bold',
-            color: 'primary',
-          }}
-        />
-      </ContainerBox>
+      <StyledWizardBaseContainer>
+        <StyledTitle>
+          <FormattedMessage description="earn.wizard.title-first-part" defaultMessage="I have" />
+        </StyledTitle>
+        <ContainerBox>
+          <Select
+            id="select-wizard-asset"
+            options={assetOptions}
+            RenderItem={TokenSelectorItem}
+            RenderSelectedValue={RenderSelectedValue}
+            selectedItem={selectedAsset}
+            SkeletonItem={SkeletonTokenSelectorItem}
+            onChange={handleAssetChange}
+            disabledSearch
+            limitHeight
+            variant="standard"
+            Header={{
+              component: HeaderItem,
+              props: {
+                label: intl.formatMessage(
+                  defineMessage({
+                    defaultMessage: 'All wallets',
+                    description: 'earn.wizard.first-part.all-wallets',
+                  })
+                ),
+                Icon: MoneysIcon,
+                secondaryLabel: capitalize(firstDropdownText),
+              },
+            }}
+            isLoading={isLoading}
+            placeholder={firstDropdownText}
+            placeholderProps={{
+              variant: 'h5Bold',
+              color: 'primary',
+            }}
+          />
+        </ContainerBox>
+      </StyledWizardBaseContainer>
+      <StyledWizardBaseContainer>
+        <StyledTitle>
+          <FormattedMessage description="earn.wizard.title-second-part" defaultMessage="and I want to generate" />
+        </StyledTitle>
+        <ContainerBox>
+          <Select
+            id="select-wizard-reward"
+            options={rewardOptions}
+            RenderItem={TokenSelectorItem}
+            RenderSelectedValue={RenderSelectedValue}
+            selectedItem={selectedReward}
+            SkeletonItem={SkeletonTokenSelectorItem}
+            onChange={handleRewardChange}
+            disabledSearch
+            limitHeight
+            variant="standard"
+            Header={{
+              component: HeaderItem,
+              props: {
+                label: capitalize(secondDropdownText),
+                Icon: Money4Icon,
+              },
+            }}
+            isLoading={isLoading}
+            placeholder={secondDropdownText}
+            placeholderProps={{
+              variant: 'h5Bold',
+              color: 'primary',
+            }}
+          />
+        </ContainerBox>
+      </StyledWizardBaseContainer>
     </StyledSelectionContainer>
   );
 };

--- a/apps/root/src/pages/earn/home/components/wizard/index.tsx
+++ b/apps/root/src/pages/earn/home/components/wizard/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { TokenSelectorOption } from '@common/components/token-selector/token-items';
 import styled, { useTheme } from 'styled-components';
-import { ForegroundPaper, DonutShape, ContainerBox, CoinStar } from 'ui-library';
-import useCurrentBreakpoint from '@hooks/useCurrentBreakpoint';
+import { ForegroundPaper, DonutShape, ContainerBox, CoinStar, useMediaQuery } from 'ui-library';
 import SuggestedStrategies from './components/suggested-strategies';
 import { WizardSelection } from './components/wizard-selection';
 
@@ -11,7 +10,7 @@ const StyledContainer = styled(ForegroundPaper).attrs({ elevation: 0 })`
     display: flex;
     flex-direction: column;
     background: ${palette.gradient.earnWizard};
-    padding: ${spacing(5)};
+    padding: ${spacing(3)};
   `}
 `;
 
@@ -22,13 +21,12 @@ export type AssetSelectorOption = TokenSelectorOption & {
 };
 
 const EarnWizard = () => {
-  const { spacing } = useTheme();
-  const currentBreakpoint = useCurrentBreakpoint();
+  const { spacing, breakpoints } = useTheme();
 
   const [selectedAsset, setSelectedAsset] = React.useState<AssetSelectorOption | undefined>();
   const [selectedReward, setSelectedReward] = React.useState<RewardSelectorOption | undefined>();
 
-  const isDownMd = currentBreakpoint === 'xs' || currentBreakpoint === 'sm';
+  const shouldShowWizard3dObject = useMediaQuery(breakpoints.down('lg'));
 
   return (
     <ContainerBox flexDirection="column" gap={10}>
@@ -39,7 +37,7 @@ const EarnWizard = () => {
           setSelectedAsset={setSelectedAsset}
           setSelectedReward={setSelectedReward}
         />
-        {!isDownMd && (
+        {!shouldShowWizard3dObject && (
           <ContainerBox style={{ position: 'relative' }} justifyContent="end" alignItems="end">
             <div style={{ position: 'absolute' }}>
               <DonutShape top={spacing(10)} />

--- a/apps/root/src/pages/earn/portfolio/components/earn-positions-table/index.tsx
+++ b/apps/root/src/pages/earn/portfolio/components/earn-positions-table/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import StrategiesTable from '@pages/earn/components/strategies-table';
+import StrategiesDisplayWrapper from '@pages/earn/components/strategies-display-wrapper';
 import { portfolioColumnConfigs } from '@pages/earn/components/strategies-table/components/columns';
 import { StrategiesTableVariants } from '@state/strategies-filters/reducer';
 import useEarnPositions from '@hooks/earn/useEarnPositions';
@@ -33,7 +33,7 @@ const EarnPositionsTable = () => {
   });
 
   return (
-    <StrategiesTable
+    <StrategiesDisplayWrapper
       columns={portfolioColumnConfigs}
       variant={variant}
       strategies={filteredStrategies}

--- a/apps/root/src/pages/earn/portfolio/components/financial-data/index.tsx
+++ b/apps/root/src/pages/earn/portfolio/components/financial-data/index.tsx
@@ -16,12 +16,21 @@ const StyledPaper = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
   `}
 `;
 
+const StyledFinancialNumbersContainer = styled(ContainerBox).attrs({ gap: 20 })`
+  ${({ theme: { breakpoints, spacing } }) => `
+  ${breakpoints.down('md')} {
+    gap: ${spacing(6)};
+    flex-direction: column;
+  }
+`}
+`;
+
 const EarnPortfolioFinancialData = () => {
   const { userStrategies, hasFetchedUserStrategies } = useEarnPositions();
 
   return (
     <StyledPaper>
-      <ContainerBox gap={20}>
+      <StyledFinancialNumbersContainer>
         <ContainerBox gap={3} flexDirection="column">
           <Typography variant="bodyBold" color={({ palette: { mode } }) => colors[mode].typography.typo1}>
             <FormattedMessage
@@ -40,7 +49,7 @@ const EarnPortfolioFinancialData = () => {
           </Typography>
           <ExpectedReturns userPositions={userStrategies} isLoading={!hasFetchedUserStrategies} size="small" />
         </ContainerBox>
-      </ContainerBox>
+      </StyledFinancialNumbersContainer>
       <EarnPositionTvlGraph />
     </StyledPaper>
   );

--- a/apps/root/src/pages/home/frame/index.tsx
+++ b/apps/root/src/pages/home/frame/index.tsx
@@ -40,6 +40,19 @@ const StyledContent = styled.div`
   flex: 1;
 `;
 
+const StyledViewportContainer = styled(Grid).attrs({
+  item: true,
+  xs: 12,
+  display: 'flex',
+})`
+  ${({ theme }) => `
+    min-height: 60vh;
+    [${theme.breakpoints.up('md')}] {
+      min-height: 50vh;
+    }
+  `}
+`;
+
 const StyledNonIndexedContainer = styled(ContainerBox).attrs({ gap: 2, alignItems: 'center' })`
   ${({ theme }) => `
     background-color: ${colors[theme.palette.mode].background.secondary};
@@ -68,8 +81,8 @@ const HomeFrame = () => {
 
   return (
     <StyledNonFormContainer>
-      <Grid container flexDirection={'column'} gap={10}>
-        <Grid container spacing={8} flexWrap="wrap">
+      <Grid container flexDirection={'column'} gap={8}>
+        <Grid container spacing={6} flexWrap="wrap">
           <Grid item xs={12} md={8} display="flex">
             <NetWorth
               walletSelector={{
@@ -85,10 +98,10 @@ const HomeFrame = () => {
             <NewsBanner />
           </Grid>
         </Grid>
-        <Grid container sx={{ flex: 1 }} spacing={8} flexWrap="wrap">
+        <Grid container sx={{ flex: 1 }} spacing={6} flexWrap="wrap">
           <Grid item xs={12} md={8}>
-            <Grid container spacing={8}>
-              <Grid item xs={12} display="flex" sx={{ minHeight: '60vh' }}>
+            <Grid container spacing={6}>
+              <StyledViewportContainer>
                 <StyledContainer>
                   <StyledFeatureTitle>
                     <FormattedMessage description="assets" defaultMessage="Assets" />
@@ -97,7 +110,7 @@ const HomeFrame = () => {
                     <Portfolio selectedWalletOption={selectedWalletOption} />
                   </StyledContent>
                 </StyledContainer>
-              </Grid>
+              </StyledViewportContainer>
               {userHasPositions && (
                 <Grid item xs={12} display="flex">
                   <StyledContent>
@@ -115,8 +128,8 @@ const HomeFrame = () => {
             </Grid>
           </Grid>
           <Grid item xs={12} md={4} display="flex">
-            <Grid container rowSpacing={8} alignContent="flex-start">
-              <Grid item xs={12} display="flex" sx={{ height: '60vh' }}>
+            <Grid container rowSpacing={6} alignContent="flex-start">
+              <StyledViewportContainer>
                 <StyledContainer>
                   <StyledFeatureTitle>
                     <FormattedMessage description="activity" defaultMessage="Activity" />
@@ -125,7 +138,7 @@ const HomeFrame = () => {
                     <Activity selectedWalletOption={selectedWalletOption} />
                   </StyledContent>
                 </StyledContainer>
-              </Grid>
+              </StyledViewportContainer>
               {hasLoadedEvents && !isSomeWalletIndexed && (
                 <Grid item xs={12} display="flex">
                   <StyledNonIndexedContainer>

--- a/apps/root/src/pages/position-detail/components/graph-container/index.tsx
+++ b/apps/root/src/pages/position-detail/components/graph-container/index.tsx
@@ -13,7 +13,6 @@ import { GraphNoData, GraphSkeleton } from './components/graph-state';
 
 const StyledContainer = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
   ${({ theme: { spacing } }) => `
-    padding: ${spacing(6)};
     gap: ${spacing(6)};
     padding-bottom: ${spacing(12)};
   `};

--- a/apps/root/src/pages/position-detail/components/summary-container/index.tsx
+++ b/apps/root/src/pages/position-detail/components/summary-container/index.tsx
@@ -23,12 +23,6 @@ import {
 import { PositionTimelineProps } from '@common/components/timeline-controls/timeline';
 import { orderBy } from 'lodash';
 
-const StyledPaper = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
-  ${({ theme: { spacing } }) => `
-    padding: ${spacing(6)}
-  `}
-`;
-
 const StyledFlexGridItem = styled(Grid)`
   display: flex;
 
@@ -111,13 +105,13 @@ const PositionSummaryContainer = ({ position, pendingTransaction, isLoading }: P
     <Grid container spacing={6} alignItems="flex-start">
       <StyledFlexGridItem item xs={12} md={5}>
         <Sticky enabled={!isDownMd} top={95}>
-          <StyledPaper>
+          <BackgroundPaper variant="outlined">
             {isLoading ? (
               <PositionDataSkeleton />
             ) : (
               position && <Details position={position} pendingTransaction={pendingTransaction} />
             )}
-          </StyledPaper>
+          </BackgroundPaper>
         </Sticky>
       </StyledFlexGridItem>
       <Grid item xs={12} md={7}>

--- a/apps/root/src/pages/strategy-guardian-detail/investment-data/components/expected-returns/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/investment-data/components/expected-returns/index.tsx
@@ -7,7 +7,7 @@ import {
 import { EarnPosition } from 'common-types';
 import React from 'react';
 import { useIntl } from 'react-intl';
-import { ContainerBox, Typography } from 'ui-library';
+import { ContainerBox, Grid, Typography } from 'ui-library';
 
 interface ExpectedReturnsProps {
   userPositions?: EarnPosition[];
@@ -20,14 +20,16 @@ const ExpectedReturns = ({ userPositions, hidePeriods, size = 'medium', isLoadin
   const intl = useIntl();
   const { earnings } = React.useMemo(() => parseUserStrategiesFinancialData(userPositions), [userPositions]);
   return (
-    <ContainerBox gap={size === 'medium' ? 16 : 6}>
+    <Grid container columnSpacing={size === 'medium' ? 16 : 6} rowSpacing={2}>
       {STRATEGY_RETURN_PERIODS.filter((period) => !hidePeriods?.includes(period.period)).map((period) => (
-        <ContainerBox flexDirection="column" key={period.period} gap={size === 'medium' ? 0 : 1}>
-          <Typography variant="bodySmallRegular">{intl.formatMessage(period.title)}</Typography>
-          <NetWorthNumber value={earnings[period.period]} isLoading={isLoading} variant="bodyBold" />
-        </ContainerBox>
+        <Grid item xs key={period.period}>
+          <ContainerBox flexDirection="column" gap={size === 'medium' ? 0 : 1}>
+            <Typography variant="bodySmallRegular">{intl.formatMessage(period.title)}</Typography>
+            <NetWorthNumber value={earnings[period.period]} isLoading={isLoading} variant="bodyBold" />
+          </ContainerBox>
+        </Grid>
       ))}
-    </ContainerBox>
+    </Grid>
   );
 };
 

--- a/apps/root/src/pages/strategy-guardian-detail/investment-data/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/investment-data/index.tsx
@@ -13,7 +13,6 @@ interface InvestmentDataProps {
 
 const StyledPaper = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
   ${({ theme: { spacing } }) => `
-    padding: ${spacing(6)};
     display: flex;
     flex-direction: column;
     gap: ${spacing(6)};

--- a/apps/root/src/pages/strategy-guardian-detail/strategy-management/components/expected-returns-changes-summary/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/strategy-management/components/expected-returns-changes-summary/index.tsx
@@ -11,7 +11,7 @@ import { DisplayStrategy } from 'common-types';
 import React from 'react';
 import { defineMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
-import { ArrowRightIcon, colors, ContainerBox, Typography } from 'ui-library';
+import { ArrowRightIcon, colors, ContainerBox, Grid, Typography } from 'ui-library';
 import { formatUnits, parseUnits } from 'viem';
 
 const StyledCurrentValueBold = styled(Typography).attrs({ variant: 'bodyBold' })`
@@ -144,36 +144,39 @@ const ExpectedReturnsChangesSummary = ({
   const hasOriginalValue = !!strategy?.userPositions && strategy?.userPositions.length > 0;
   const hasNewValues = !!updatedUserPositions && updatedUserPositions.length > 0;
   return (
-    <ContainerBox gap={size === 'medium' ? 16 : 6} flexWrap="wrap">
+    <Grid container columnSpacing={size === 'medium' ? 16 : 6} rowSpacing={3}>
       {includeSummaryItem && (
-        <SummaryItem
-          currentValue={totalInvestedUsd}
-          updatedValue={updatedTotalInvestedUsd}
-          isLoading={isLoading}
-          hasOriginalValue={hasOriginalValue}
-          hasNewValues={hasNewValues}
-          title={intl.formatMessage(
-            defineMessage({
-              defaultMessage: 'Total invested',
-              description: 'earn.strategy-management.changes-summary.total-invested',
-            })
-          )}
-          gap={size === 'medium' ? 0 : 1}
-        />
+        <Grid item xs>
+          <SummaryItem
+            currentValue={totalInvestedUsd}
+            updatedValue={updatedTotalInvestedUsd}
+            isLoading={isLoading}
+            hasOriginalValue={hasOriginalValue}
+            hasNewValues={hasNewValues}
+            title={intl.formatMessage(
+              defineMessage({
+                defaultMessage: 'Total invested',
+                description: 'earn.strategy-management.changes-summary.total-invested',
+              })
+            )}
+            gap={size === 'medium' ? 0 : 1}
+          />
+        </Grid>
       )}
       {STRATEGY_RETURN_PERIODS.filter((period) => !hidePeriods?.includes(period.period)).map((period) => (
-        <SummaryItem
-          key={period.period}
-          currentValue={earnings[period.period]}
-          updatedValue={updatedEarnings[period.period]}
-          isLoading={isLoading}
-          hasOriginalValue={hasOriginalValue}
-          hasNewValues={hasNewValues}
-          title={intl.formatMessage(period.title)}
-          gap={size === 'medium' ? 0 : 1}
-        />
+        <Grid item xs key={period.period}>
+          <SummaryItem
+            currentValue={earnings[period.period]}
+            updatedValue={updatedEarnings[period.period]}
+            isLoading={isLoading}
+            hasOriginalValue={hasOriginalValue}
+            hasNewValues={hasNewValues}
+            title={intl.formatMessage(period.title)}
+            gap={size === 'medium' ? 0 : 1}
+          />
+        </Grid>
       ))}
-    </ContainerBox>
+    </Grid>
   );
 };
 

--- a/apps/root/src/pages/strategy-guardian-detail/strategy-management/deposit/tx-manager/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/strategy-management/deposit/tx-manager/index.tsx
@@ -8,7 +8,7 @@ import { ContainerBox } from 'ui-library';
 import EarnTransactionSteps from '../tx-steps';
 
 const StyledButtonContainer = styled(ContainerBox).attrs(() => ({ alignItems: 'center', justifyContent: 'center' }))`
-  margin-top: ${({ theme }) => theme.spacing(3)};
+  margin-top: ${({ theme }) => theme.spacing(2)};
 `;
 
 interface EarnDepositTransactionManagerProps {

--- a/apps/root/src/pages/strategy-guardian-detail/strategy-management/withdraw/tx-manager/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/strategy-management/withdraw/tx-manager/index.tsx
@@ -8,7 +8,7 @@ import useEarnWithdrawActions from '../hooks/useEarnWithdrawActions';
 import EarnWithdrawTransactionSteps from '../tx-steps';
 
 const StyledButtonContainer = styled(ContainerBox).attrs({ alignItems: 'center', justifyContent: 'center' })`
-  margin-top: ${({ theme }) => theme.spacing(3)};
+  margin-top: ${({ theme }) => theme.spacing(2)};
 `;
 
 interface EarnWithdrawTransactionManagerProps {

--- a/apps/root/src/pages/strategy-guardian-detail/vault-data/components/data-cards/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/vault-data/components/data-cards/index.tsx
@@ -18,7 +18,7 @@ import { SPACING } from 'ui-library/src/theme/constants';
 
 export enum DataCardVariants {
   Details = 'details',
-  Wizard = 'wizard',
+  Home = 'home',
 }
 
 interface DataCardsProps {
@@ -152,7 +152,7 @@ const DataCards = ({ strategy, dataCardsGap = 4, variant = DataCardVariants.Deta
           variant={variant}
         />
       </ContainerBox>
-      {variant === DataCardVariants.Wizard && (
+      {variant === DataCardVariants.Home && (
         <ContainerBox flexDirection="column" justifyContent="stretch">
           <DividerBorder2 />
           <StyledDataCardYieldTypeBox alignItems="center" justifyContent="center">

--- a/apps/root/src/pages/strategy-guardian-detail/vault-data/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/vault-data/index.tsx
@@ -1,6 +1,5 @@
 import { DisplayStrategy } from 'common-types';
 import React from 'react';
-import styled from 'styled-components';
 import { BackgroundPaper, ContainerBox } from 'ui-library';
 import DataHeader from './components/data-header';
 import DataCards from './components/data-cards';
@@ -11,22 +10,16 @@ interface VaultDataProps {
   strategy?: DisplayStrategy;
 }
 
-const StyledPaper = styled(BackgroundPaper).attrs({ variant: 'outlined' })`
-  ${({ theme: { spacing } }) => `
-    padding: ${spacing(6)}
-  `}
-`;
-
 const VaultData = ({ strategy }: VaultDataProps) => {
   return (
-    <StyledPaper>
+    <BackgroundPaper variant="outlined">
       <ContainerBox flexDirection="column" alignItems="stretch" gap={6}>
         <DataHeader strategy={strategy} />
         <DataCards strategy={strategy} />
         {!!strategy?.guardian && <DataGuardian strategy={strategy} />}
         <DataAbout strategy={strategy} collapsed />
       </ContainerBox>
-    </StyledPaper>
+    </BackgroundPaper>
   );
 };
 

--- a/packages/ui-library/src/components/dashboard/index.tsx
+++ b/packages/ui-library/src/components/dashboard/index.tsx
@@ -210,7 +210,7 @@ const Dashboard = ({
               <Grid item xs={1}>
                 <StyledBullet fill={dataPoint.fill} />
               </Grid>
-              <Grid item xs={3}>
+              <Grid item xs={3} textOverflow="ellipsis" overflow="hidden">
                 <Typography variant="bodySmallSemibold" color={({ palette }) => colors[palette.mode].typography.typo2}>
                   {dataPoint.name}
                 </Typography>

--- a/packages/ui-library/src/components/navigation/index.tsx
+++ b/packages/ui-library/src/components/navigation/index.tsx
@@ -22,7 +22,7 @@ import { ListItemButton } from '../listitembutton';
 import { ListItemIcon } from '../listitemicon';
 import { ListItemText } from '../listitemtext';
 import { Container } from '../container';
-import { Link, Typography, useTheme } from '@mui/material';
+import { Link, Typography, useMediaQuery, useTheme } from '@mui/material';
 import BalmyLogoLight from '../../assets/balmy-logo-light';
 import BalmyLogoDark from '../../assets/balmy-logo-dark';
 import styled from 'styled-components';
@@ -72,7 +72,7 @@ type NavigationProps = React.PropsWithChildren<{
   headerContent?: React.ReactNode;
 }>;
 
-const drawerWidthMd = 240;
+const drawerWidthLg = 240;
 const drawerWidthSm = 200;
 
 const StyledIconToolbar = styled(Toolbar)`
@@ -342,12 +342,13 @@ const Navigation = ({
     spacing,
     breakpoints,
   } = useTheme();
+  const isDownLg = useMediaQuery(breakpoints.down('lg'));
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
   };
 
-  const drawerWidth = breakpoints.down('md') ? drawerWidthSm : drawerWidthMd;
+  const drawerWidth = isDownLg ? drawerWidthSm : drawerWidthLg;
   const drawerLinks = buildDrawer({ sections, selectedSection, onSectionClick });
 
   const iconProps = { cursor: 'pointer', onClick: onClickBrandLogo, size: '110px' };
@@ -466,7 +467,7 @@ const Navigation = ({
           flexDirection: 'column',
           p: 3,
           width: { md: `calc(100% - ${drawerWidth}px)` },
-          alignSelf: 'flex-end',
+          alignSelf: { md: 'flex-end' },
           padding: 0,
           maxWidth: '100%',
           alignItems: 'center',

--- a/packages/ui-library/src/theme/constants.ts
+++ b/packages/ui-library/src/theme/constants.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_SPACING = 4;
 export const DEFAULT_BORDER_RADIUS = 16;
 export const SPACING = (value: number) => `${DEFAULT_SPACING * value}px`;
-export const MAX_FORM_WIDTH = SPACING(158);
+export const MAX_FORM_WIDTH = SPACING(158); // 632px
 
 export const baseSpacingScale: Record<'none' | 's01' | 's02' | 's03' | 's04' | 's05' | 's06' | 's07', string> = {
   none: SPACING(0), // 0px


### PR DESCRIPTION
# Fixes addressed in this Pull Request:

### Main App Grid
Limited width for smaller devices, ensuring padding-y (As suggested by designer in our Notion)

### Navigation
Now it takes 240px for lg and higher breakpoints, 200px for the rest (As suggested by designer in our Notion)

### Timeline Controls
| <img width="461" alt="Screenshot 2024-09-23 at 5 23 20 PM" src="https://github.com/user-attachments/assets/8327a69c-b6ef-4a4f-ac81-da5266b8b071"> | <img width="407" alt="Screenshot 2024-09-23 at 5 22 11 PM" src="https://github.com/user-attachments/assets/5aa418e9-d508-492b-acbe-8c90ab37d1b8">|
|------------------------|------------------------|
| Current   | Proposal    |

### Aggregator Settings
| <img width="410" alt="Screenshot 2024-09-23 at 5 24 42 PM" src="https://github.com/user-attachments/assets/51c54471-a860-4d36-abbe-18dccf1292ec"> | <img width="410" alt="Screenshot 2024-09-23 at 5 25 13 PM" src="https://github.com/user-attachments/assets/1c825556-ffe9-4209-b04c-1a1304c31bda">|
|------------------------|------------------------|
| Current   | Proposal    |

### DCA Positions Grid
This looks much the same, but while having md={10} in the main <App /> container with this implementation, we would be having one column below the `md` breakpoint

### Earn Wizard
| <img width="415" alt="Screenshot 2024-09-23 at 5 31 13 PM" src="https://github.com/user-attachments/assets/0612fdd3-1629-479f-9c31-e0f2677a1105"> | <img width="404" alt="Screenshot 2024-09-23 at 5 31 43 PM" src="https://github.com/user-attachments/assets/f87c57ad-3a97-4439-a18d-64d58516e993">|
|------------------------|------------------------|
| Current   | Proposal    |

### Strategies Table (Home & Portfolio)
| <img width="414" alt="Screenshot 2024-09-23 at 5 34 04 PM" src="https://github.com/user-attachments/assets/e146e105-60f6-4198-a473-efb76a41eced"> | <img width="415" alt="Screenshot 2024-09-23 at 5 34 39 PM" src="https://github.com/user-attachments/assets/06582e05-c306-4cb7-ab66-badbb807f4da">|
|------------------------|------------------------|
| Current   | Proposal    |

### Earn Portfolio Financial Data
| <img width="423" alt="Screenshot 2024-09-23 at 5 37 45 PM" src="https://github.com/user-attachments/assets/b337fd27-8580-4e73-9a7a-a0f17c6e856a"> | <img width="408" alt="Screenshot 2024-09-23 at 5 37 59 PM" src="https://github.com/user-attachments/assets/a1cd5191-744d-44c9-ba4a-0d1e06f787f3">|
|------------------------|------------------------|
| Current   | Proposal    |

### DCA Dashboard
| <img width="776" alt="Screenshot 2024-09-23 at 5 38 49 PM" src="https://github.com/user-attachments/assets/c60f13b7-6c47-471e-81ad-efca055148d7"> | <img width="710" alt="Screenshot 2024-09-23 at 5 39 22 PM" src="https://github.com/user-attachments/assets/dc99d352-28c7-44f9-91fb-cd5e6987ac75">|
|------------------------|------------------------|
| Current   | Proposal    |
