### PR TITLE
fix(earn): review withdraw flow

### DIFF
--- a/apps/root/src/common/utils/earn/parsing.tsx
+++ b/apps/root/src/common/utils/earn/parsing.tsx
@@ -355,7 +355,7 @@ export function parseUserStrategiesFinancialData(userPositions: EarnPosition[] =
     }
   );
 
-  const currentProfitRate = (currentProfitUsd / totalInvestedUsd) * 100;
+  const currentProfitRate = totalInvestedUsd !== 0 ? (currentProfitUsd / totalInvestedUsd) * 100 : 0;
 
   return { totalInvestedUsd, currentProfitUsd, currentProfitRate, earnings };
 }

--- a/apps/root/src/pages/strategy-guardian-detail/frame/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/frame/index.tsx
@@ -17,6 +17,7 @@ import { identifyNetwork } from '@common/utils/parsing';
 import StrategyManagement from '../strategy-management';
 import { getAllChains } from '@balmy/sdk';
 import { StrategyId } from 'common-types';
+import { resetEarnForm } from '@state/earn-management/actions';
 
 const StyledFlexGridItem = styled(Grid)`
   display: flex;
@@ -74,6 +75,8 @@ const StrategyDetailFrame = () => {
 
   React.useEffect(() => {
     if (strategyGuardianId) {
+      dispatch(resetEarnForm());
+
       try {
         void earnService.fetchMultipleEarnPositionsFromStrategy(strategyGuardianId);
       } catch (error) {

--- a/apps/root/src/pages/strategy-guardian-detail/strategy-management/withdraw/cta-button/index.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/strategy-management/withdraw/cta-button/index.tsx
@@ -70,7 +70,11 @@ const EarnWithdrawCTAButton = ({
     parseUnits(withdrawAmount, asset.decimals) > positionBalance.amount.amount;
 
   const shouldDisableProceedButton =
-    !asset || !withdrawAmount || !positionBalance || isLoading || notEnoughPositionAssetBalance;
+    !asset ||
+    !positionBalance ||
+    isLoading ||
+    notEnoughPositionAssetBalance ||
+    (Number(withdrawAmount || '0') === 0 && !withdrawRewards);
 
   // User can just withdraw if they have rewards
   const shouldDisabledButton = !withdrawRewards && shouldDisableProceedButton;
@@ -227,7 +231,7 @@ const EarnWithdrawCTAButton = ({
     ButtonToShow = ReconnectWalletButton;
   } else if (!isOnCorrectNetwork) {
     ButtonToShow = IncorrectNetworkButton;
-  } else if (notEnoughPositionAssetBalance && !withdrawRewards) {
+  } else if (notEnoughPositionAssetBalance) {
     ButtonToShow = NoEnoughPositionBalanceButton;
   } else if (shouldHandleDelayWithdraw) {
     ButtonToShow = DelayWithdrawButtons;

--- a/apps/root/src/pages/strategy-guardian-detail/strategy-management/withdraw/hooks/useEarnWithdrawActions.tsx
+++ b/apps/root/src/pages/strategy-guardian-detail/strategy-management/withdraw/hooks/useEarnWithdrawActions.tsx
@@ -48,7 +48,7 @@ const useEarnWithdrawActions = ({ strategy }: UseEarnWithdrawActionsParams) => {
   const [shouldShowMarketWithdrawModal, setShouldShowMarketWithdrawModal] = React.useState(false);
 
   const tokensToWithdraw = React.useMemo(() => {
-    if (!activeWallet?.address || !strategy || !asset || !assetAmountInUnits) return;
+    if (!activeWallet?.address || !strategy || !asset) return;
 
     const currentPosition =
       activeWallet && strategy?.userPositions?.find((position) => position.owner === activeWallet.address);

--- a/apps/root/src/services/earnService.ts
+++ b/apps/root/src/services/earnService.ts
@@ -643,11 +643,11 @@ export class EarnService extends EventsManager<EarnServiceData> {
       const originalTokenBalance = userStrategy.balances.find(
         (b) => b.token.address.toLowerCase() === w.token.address.toLowerCase()
       );
-      const isRewardToken = !!strategy.farm.rewards?.tokens.find(
-        (t) => t.address.toLowerCase() === w.token.address.toLowerCase()
-      );
 
-      const amount = isRewardToken || originalTokenBalance?.amount.amount === w.amount ? maxUint256 : w.amount;
+      const shouldWithdrawMax =
+        originalTokenBalance?.amount.amount !== 0n && originalTokenBalance?.amount.amount === w.amount;
+
+      const amount = shouldWithdrawMax ? maxUint256 : w.amount;
       return {
         token: w.token.address,
         amount,

--- a/packages/ui-library/src/components/token-amount-usd-input/index.tsx
+++ b/packages/ui-library/src/components/token-amount-usd-input/index.tsx
@@ -167,6 +167,7 @@ const TokenInput = ({ onChange, value, token, tokenPrice, onBlur, onFocus, disab
           autoComplete="off"
           placeholder="0.0"
           disableUnderline
+          disabled={disabled}
           inputProps={{
             style: {
               color: getInputColor({ disabled, mode, hasValue: !isUndefined(value) }),
@@ -210,6 +211,7 @@ const UsdInput = ({ onChange, value, token, tokenPrice, onBlur, onFocus, disable
           autoComplete="off"
           placeholder="0.00"
           disableUnderline
+          disabled={disabled}
           inputProps={{
             style: {
               color: getInputColor({ disabled, mode, hasValue: !isUndefined(value) }),
@@ -354,7 +356,7 @@ const TokenAmounUsdInput = ({ token, balance, tokenPrice, value, onChange, disab
   return (
     <InputContainer isFocused={isFocused} alignItems="center" disabled={disabled} padding="0 !important">
       <InputContentContainer>
-        <StyledIconButton color="primary" disabled={isUndefined(tokenPrice)} onClick={onChangeType}>
+        <StyledIconButton color="primary" disabled={isUndefined(tokenPrice) || disabled} onClick={onChangeType}>
           <ToggleArrowIcon sx={{ color: colors[mode].accent.primary }} />
         </StyledIconButton>
         <ContainerBox alignItems="center" gap={2} flex={1}>
@@ -399,7 +401,7 @@ const TokenAmounUsdInput = ({ token, balance, tokenPrice, value, onChange, disab
               {` `}
               {formatCurrencyAmount({ amount: balance.amount, token: token || undefined, intl })}
             </Typography>
-            <StyledButton size="small" variant="text" onClick={onMaxValueClick}>
+            <StyledButton size="small" variant="text" onClick={onMaxValueClick} disabled={disabled}>
               <FormattedMessage defaultMessage="Max" description="max" />
             </StyledButton>
           </StyledFooter>


### PR DESCRIPTION
### Related issues
- [BLY-3249](https://linear.app/balmy/issue/BLY-3249/no-se-marcan-cambios-en-el-resumen-al-hacer-withdraw
)
- [BLY-3248](https://linear.app/balmy/issue/BLY-3248/ocultar-checkbox-withdraw-rewards-si-no-hay-rewards
)
- [BLY-3282](https://linear.app/balmy/issue/BLY-3282/earn-form-state-persists-across-al-strategies-with-different-tokens
)
- [BLY-3253](https://linear.app/balmy/issue/BLY-3253/problemas-al-retirar-rewards-y-calculo-de-returns-roto)