### PR TITLE
fix: encode signature bytes correctly

### DIFF
--- a/apps/root/src/services/meanApiService.ts
+++ b/apps/root/src/services/meanApiService.ts
@@ -633,7 +633,7 @@ export default class MeanApiService {
     accountId: string;
     strategyId: StrategyId;
     toValidate: Address;
-    deadline: number;
+    deadline: bigint;
   }) {
     return this.authorizedRequest<{ signature: Hex }>({
       method: 'GET',
@@ -642,7 +642,7 @@ export default class MeanApiService {
       params: {
         strategyId,
         toValidate,
-        deadline,
+        deadline: deadline.toString(),
       },
     });
   }


### PR DESCRIPTION
The signature based manager actually expected the received `bytes` to be an encoded version of `(bytes signature, uint deadline)`. We were only sending the signature, so we now need to fix this