### PR TITLE
fix(*): transaction confirmation when using rabby gas account

### DIFF
--- a/apps/root/src/common/utils/transactions.spec.ts
+++ b/apps/root/src/common/utils/transactions.spec.ts
@@ -1,0 +1,31 @@
+import { TransactionDetails, TransactionTypes } from '@types';
+import { toToken } from './currency';
+import { getProtocolTokenTransactionAmount } from './transactions';
+import { PROTOCOL_TOKEN_ADDRESS } from '@common/mocks/tokens';
+
+describe('transactions', () => {
+  describe('getProtocolTokenTransactionAmount', () => {
+    it('should return 0 for a transaction that is not a protocol token transaction', () => {
+      const result = getProtocolTokenTransactionAmount({
+        type: TransactionTypes.approveToken,
+        typeData: {
+          token: toToken({ address: '0x123' }),
+          addressFor: '0x0',
+        },
+      } as TransactionDetails);
+
+      expect(result).toEqual(0n);
+    });
+    it('should return the amount of the protocol token for a transaction that is a protocol token transaction', () => {
+      const result = getProtocolTokenTransactionAmount({
+        type: TransactionTypes.earnCreate,
+        typeData: {
+          asset: toToken({ address: PROTOCOL_TOKEN_ADDRESS }),
+          assetAmount: '100',
+        },
+      } as TransactionDetails);
+
+      expect(result).toEqual(100n);
+    });
+  });
+});

--- a/apps/root/src/constants/transactions.ts
+++ b/apps/root/src/constants/transactions.ts
@@ -1,6 +1,7 @@
 import { Chains } from '@balmy/sdk';
 
 export const DEFAULT_TRANSACTION_RETRIES = 10;
+export const RABBY_GAS_ACCOUNT_RETRIES = 60;
 
 export const TRANSACTION_RETRIES_PER_NETWORK = {
   [Chains.ROOTSTOCK.chainId]: 90,

--- a/apps/root/src/state/balances/hooks.ts
+++ b/apps/root/src/state/balances/hooks.ts
@@ -171,6 +171,39 @@ export function useStoredNativeBalance(chainId: number) {
   }));
 }
 
+export function useNativeBalancesSnapshot() {
+  const allBalances = useAppSelector((state: RootState) => state.balances);
+  const [snapshot, setSnapshot] = React.useState<Record<ChainId, { [walletAddress: Address]: bigint }>>({});
+
+  const balances: Record<ChainId, { [walletAddress: Address]: bigint }> = {};
+
+  Object.entries(allBalances.balances).forEach(([chainId, chainBalances]) => {
+    const protocolTokenBalances = chainBalances.balancesAndPrices?.[PROTOCOL_TOKEN_ADDRESS];
+    balances[Number(chainId)] = {
+      ...balances[Number(chainId)],
+      ...(protocolTokenBalances?.balances || {}),
+    };
+  });
+
+  const updateNativeBalancesSnapshot = () => {
+    setSnapshot(balances);
+  };
+
+  React.useEffect(() => {
+    if (Object.keys(balances).length > 0 && Object.keys(snapshot).length === 0) {
+      updateNativeBalancesSnapshot();
+    }
+  }, [balances]);
+
+  return React.useMemo(
+    () => ({
+      nativeBalancesSnapshot: snapshot,
+      updateNativeBalancesSnapshot,
+    }),
+    [snapshot, updateNativeBalancesSnapshot]
+  );
+}
+
 export function useTotalTokenBalance(token?: Token) {
   const intl = useIntl();
   const allBalances = useAppSelector((state: RootState) => state.balances);

--- a/packages/ui-library/src/components/transaction-confirmation/index.tsx
+++ b/packages/ui-library/src/components/transaction-confirmation/index.tsx
@@ -18,7 +18,6 @@ import { colors } from '../../theme';
 import { Address } from 'viem';
 import { FormattedMessage, MessageDescriptor, defineMessage, useIntl } from 'react-intl';
 import { SuccessCircleIcon } from '../../icons';
-import { Chains } from '@balmy/sdk';
 import { SPACING } from '../../theme/constants';
 import CustomerSatisfaction, { FeedbackOption } from '../customer-satisfaction';
 import capitalize from 'lodash/capitalize';
@@ -90,16 +89,6 @@ export const satisfactionOptions: FeedbackOption[] = [
   GrinningFaceWithBigEyesEmoji,
   SmilingFaceWithHeartEyesEmoji,
 ].map((Emoji, i) => ({ label: <Emoji key={i} size={SPACING(7)} />, value: i + 1 }));
-
-const TIMES_PER_NETWORK = {
-  [Chains.ARBITRUM.chainId]: 10,
-  [Chains.POLYGON.chainId]: 20,
-  [Chains.OPTIMISM.chainId]: 10,
-  [Chains.ETHEREUM.chainId]: 40,
-  [Chains.ROOTSTOCK.chainId]: 90,
-};
-
-export const DEFAULT_TIME_PER_NETWORK = 30;
 
 interface CostBalanceChangeProps {
   cost: AmountsOfToken;
@@ -312,19 +301,19 @@ const SuccessTransactionConfirmation = ({
 interface PendingTransactionConfirmationProps {
   onGoToEtherscan: () => void;
   mode: 'light' | 'dark';
-  chainId?: number;
   loadingSubtitle?: string;
   loadingTitle?: React.ReactNode;
+  maxWaitingTime: number;
 }
 
 const PendingTransactionConfirmation = ({
   onGoToEtherscan,
   mode,
-  chainId,
   loadingSubtitle,
   loadingTitle,
+  maxWaitingTime,
 }: PendingTransactionConfirmationProps) => {
-  const [timer, setTimer] = useState(TIMES_PER_NETWORK[chainId || 1] || DEFAULT_TIME_PER_NETWORK);
+  const [timer, setTimer] = useState(maxWaitingTime);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -361,7 +350,7 @@ const PendingTransactionConfirmation = ({
         <CircularProgress
           size={232}
           variant="determinate"
-          value={(1 - timer / (TIMES_PER_NETWORK[chainId || 1] || DEFAULT_TIME_PER_NETWORK)) * 100}
+          value={(1 - timer / maxWaitingTime) * 100}
           thickness={4}
           sx={{
             [`& .${circularProgressClasses.circle}`]: {
@@ -426,6 +415,7 @@ interface TransactionConfirmationProps {
   successSubtitle?: React.ReactNode;
   onClickSatisfactionOption: (value: number) => void;
   setHeight?: (a?: number) => void;
+  maxWaitingTime: number;
 }
 
 const StyledContainer = styled(ContainerBox).attrs({ gap: 10, fullWidth: true, flexDirection: 'column' })<{
@@ -453,7 +443,6 @@ const StyledContainer = styled(ContainerBox).attrs({ gap: 10, fullWidth: true, f
 const TransactionConfirmation = ({
   shouldShow,
   success,
-  chainId,
   onGoToEtherscan,
   balanceChanges,
   gasUsed,
@@ -466,6 +455,7 @@ const TransactionConfirmation = ({
   loadingSubtitle,
   loadingTitle,
   setHeight,
+  maxWaitingTime,
 }: TransactionConfirmationProps) => {
   const {
     palette: { mode },
@@ -507,9 +497,9 @@ const TransactionConfirmation = ({
             <PendingTransactionConfirmation
               loadingSubtitle={loadingSubtitle}
               loadingTitle={loadingTitle}
-              chainId={chainId}
               onGoToEtherscan={onGoToEtherscan}
               mode={mode}
+              maxWaitingTime={maxWaitingTime}
             />
           )}
         </StyledOverlay>


### PR DESCRIPTION
### Summary
This update improves transaction handling for users leveraging Rabby’s gas account feature. When a Rabby wallet is detected and the current ETH balance is insufficient to cover gas fees, we assume that the user intends to use the gas account functionality. 
In these cases, we extend the transaction confirmation period to three times the usual duration to account for the additional delay incurred while waiting for the gas top-up. Additionally, for transactions involving native tokens (such as ETH transfers), the required gas is now validated against the user’s current balance before processing.