### PR TITLE
fix(*): rainbow kit optimization

### DIFF
--- a/apps/root/src/frame/index.tsx
+++ b/apps/root/src/frame/index.tsx
@@ -55,7 +55,17 @@ const StyledGridContainer = styled(Grid)<{ isSmall?: boolean }>`
   `}
 `;
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      enabled: false,
+      refetchOnWindowFocus: false,
+      retryOnMount: false,
+      staleTime: Infinity,
+      retry: false,
+    },
+  },
+});
 
 const StyledAppGridContainer = styled(Grid)`
   ${({ theme: { spacing, breakpoints } }) => `


### PR DESCRIPTION
### Context
RainbowKit uses a Wagmi hook called `useEns`, which is built into the `RainbowKitProvider`. Wagmi hooks usually rely on the `@tanstack/react-query` package to refetch and cache data. Even though I tried, I couldn’t stop the `useEns` call from happening every time a user connects their wallet to the page. However, since we don’t use Wagmi hooks at all, applying some minimization of TanStack usage (reducing retries and refetches) allowed us to achieve significant performance improvements.

Requests before:
<img width="1440" alt="Screenshot 2025-02-24 at 4 44 57 PM" src="https://github.com/user-attachments/assets/437f5ba2-3c8d-4121-9572-d3a992c5dd26" />
Request after:
<img width="1440" alt="Screenshot 2025-02-24 at 4 47 43 PM" src="https://github.com/user-attachments/assets/7182e27a-b2f7-4241-a0d6-41f3e9a4b7b8" />

Useful docs:
- How to config tanstack [TanStack Query Documentation](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery#usequery)
- Wagmi hook in Rainbow: [RainbowKit GitHub Source](https://github.com/rainbow-me/rainbowkit/blob/ed13be55111b6d16c229ff2e7e615c4e225cf29e/packages/rainbowkit/src/components/AccountModal/AccountModal.tsx#L15)
